### PR TITLE
Import hex code

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,104 @@
+on:
+  push:
+    branches:
+      - master
+      - 'test-ci/**'
+  pull_request:
+
+name: Continuous integration
+
+jobs:
+  Stable:
+    name: Test - stable toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        # https://github.com/dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Running test script
+        env:
+          DO_LINT: true
+          DO_DOCS: true
+          DO_FEATURE_MATRIX: true
+        run: ./contrib/test.sh
+
+  Beta:
+    name: Test - beta toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@beta
+      - name: Running test script
+        run: ./contrib/test.sh
+
+  Nightly:
+    name: Test - nightly toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Running test script
+        env:
+          DO_FMT: true
+          DO_DOCSRS: true
+        run: ./contrib/test.sh
+
+  MSRV:
+    name: Test - 1.48.0 toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@1.48.0
+      - name: Running test script
+        env:
+          DO_FEATURE_MATRIX: true
+        run: ./contrib/test.sh
+
+  Arch32bit:
+    name: Test 32-bit version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Add architecture i386
+        run: sudo dpkg --add-architecture i386
+      - name: Install i686 gcc
+        run: sudo apt-get update -y && sudo apt-get install -y gcc-multilib
+      - name: Install target
+        run: rustup target add i686-unknown-linux-gnu
+      - name: Run test on i686
+        run: cargo test --target i686-unknown-linux-gnu
+
+  Cross:
+    name: Cross test
+    if: ${{ !github.event.act }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install target
+        run: rustup target add s390x-unknown-linux-gnu
+      - name: install cross
+        run: cargo install cross --locked
+      - name: run cross test
+        run: cross test --target s390x-unknown-linux-gnu

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-/target
+# .gitignore for hex-conservative repository.
+
+Cargo.lock
+target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,30 @@
 [package]
 name = "hex-conservative"
 version = "0.0.1"
-edition = "2018"
-description = "A hex encoding and decoding crate with a conservative MSRV and dependency policy."
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/hex-conservative"
+documentation = "https://docs.rs/hex-conservative/"
+description = "A hex encoding and decoding crate with a conservative MSRV and dependency policy."
+categories = ["encoding"]
+keywords = ["encoding", "hex", "hexadecimal"]
+readme = "README.md"
+edition = "2018"
+exclude = ["tests", "contrib"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+core2 = { version = "0.3.2", default_features = false, optional = true }
+
+[dev-dependencies]
+
+[[example]]
+name = "hexy"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Bitcoin Hexadecimal Library
+
+General purpose hex encoding/decoding library with a conservative MSRV and dependency policy.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should compile with almost any combination of features on **Rust 1.48.0**, however we
+reserve the right to use features to guard compiler specific code so `--all-features` may not work
+using the MSRV toolchain.
+
+### Githooks
+
+To assist devs in catching errors _before_ running CI we provide some githooks. If you do not
+already have locally configured githooks you can use the ones in this repository by running, in the
+root directory of the repository:
+```
+git config --local core.hooksPath githooks/
+```
+
+Alternatively add symlinks in your `.git/hooks` directory to any of the githooks we provide.

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+set -ex
+
+FEATURES="std alloc core2"
+
+cargo --version
+rustc --version
+
+# Work out if we are using a nightly toolchain.
+NIGHTLY=false
+if cargo --version | grep nightly >/dev/null; then
+    NIGHTLY=true
+fi
+
+# Make all cargo invocations verbose
+export CARGO_TERM_VERBOSE=true
+
+# Defaults / sanity checks
+cargo build
+cargo test
+
+cargo run --example hexy
+
+if [ "$DO_LINT" = true ]
+then
+    cargo clippy --all-features --all-targets -- -D warnings
+    cargo clippy --locked --example hexy -- -D warnings
+fi
+
+if [ "$DO_FEATURE_MATRIX" = true ]; then
+    cargo build --locked --no-default-features
+    cargo test --locked --no-default-features
+
+    # All features
+    cargo build --locked --no-default-features --features="$FEATURES"
+    cargo test --locked --no-default-features --features="$FEATURES"
+    # Single features
+    for feature in ${FEATURES}
+    do
+        cargo build --locked --no-default-features --features="$feature"
+        cargo test --locked --no-default-features --features="$feature"
+		# All combos of two features
+		for featuretwo in ${FEATURES}; do
+			cargo build --locked --no-default-features --features="$feature $featuretwo"
+			cargo test --locked --no-default-features --features="$feature $featuretwo"
+		done
+    done
+fi
+
+# Build the docs if told to (this only works with the nightly toolchain)
+if [ "$DO_DOCSRS" = true ]; then
+    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" cargo +nightly doc --all-features
+fi
+
+# Build the docs with a stable toolchain, in unison with the DO_DOCSRS command
+# above this checks that we feature guarded docs imports correctly.
+if [ "$DO_DOCS" = true ]; then
+    RUSTDOCFLAGS="-D warnings" cargo +stable doc --all-features
+fi
+
+# Run formatter if told to.
+if [ "$DO_FMT" = true ]; then
+    if [ "$NIGHTLY" = false ]; then
+        echo "DO_FMT requires a nightly toolchain (consider using RUSTUP_TOOLCHAIN)"
+        exit 1
+    fi
+    rustup component add rustfmt
+    cargo fmt --check
+fi

--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -1,0 +1,71 @@
+//! Demonstrate basic hexadecimal encoding and decoding.
+//!
+//! For basic encoding and decoding see crate level rustdoc in `lib.rs`.
+
+use std::fmt;
+use std::str::FromStr;
+
+use hex_conservative::{fmt_hex_exact, Case, Error, FromHex};
+
+fn main() {
+    let s = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
+    let hexy = Hexy::from_hex(s).expect("valid hex digits");
+    let display = format!("{}", hexy);
+
+    assert_eq!(display, s);
+}
+
+/// A struct that always uses hex when in string form.
+pub struct Hexy {
+    // Some opaque data.
+    data: [u8; 32],
+}
+
+impl Hexy {
+    /// Demonstrates getting internal opaque data as a byte slice.
+    pub fn as_bytes(&self) -> &[u8] { &self.data }
+}
+
+// Note we implement `Display` and `FromStr` using `LowerHex`/`FromHex` respectively, if this was a
+// not-so-hexy object then these impls would return a different string format.
+
+impl fmt::Display for Hexy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
+}
+
+impl FromStr for Hexy {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> { Hexy::from_hex(s) }
+}
+
+// Implement conversion to hex by first converting our type to a byte slice.
+
+impl fmt::LowerHex for Hexy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // This is equivalent to but more performan than:
+        // fmt::LowerHex::fmt(&self.as_bytes().as_hex(), f)
+        fmt_hex_exact!(f, 32, self.as_bytes(), Case::Lower)
+    }
+}
+
+impl fmt::UpperHex for Hexy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // This is equivalent to but more performan than:
+        // fmt::UpperHex::fmt(&self.as_bytes().as_hex(), f)
+        fmt_hex_exact!(f, 32, self.as_bytes(), Case::Upper)
+    }
+}
+
+// And use a fixed size array to convert from hex.
+
+impl FromHex for Hexy {
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
+    {
+        // Errors if the iterator is the wrong length.
+        let a = <[u8; 32] as FromHex>::from_byte_iter(iter)?;
+        Ok(Hexy { data: a })
+    }
+}

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Verify what is about to be committed. Called by "git commit" with no
+# arguments. The hook should exit with non-zero status after issuing an
+# appropriate message if it wants to stop the commit.
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --check --cached $against -- || exit 1
+
+# Check that code lints cleanly.
+cargo clippy --all-features -- -D warnings || exit 1
+
+# Check that there are no formatting issues.
+cargo +nightly fmt --check || exit 1

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,86 @@
+# Eventually this shoud be: ignore = []
+ignore = [
+       "bitcoin/src/blockdata",
+       "bitcoin/src/consensus",
+       "bitcoin/src/crypto",
+       "bitcoin/src/psbt",
+       "bitcoin/src/util",
+       "hashes",
+]
+
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Auto"
+indent_style = "Block"
+
+max_width = 100 # This is number of characters.
+# `use_small_heuristics` is ignored if the granular width config values are explicitly set.
+use_small_heuristics = "Max"    # "Max" == All granular width settings same as `max_width`.
+# # Granular width configuration settings. These are percentages of `max_width`.
+# fn_call_width = 60
+# attr_fn_like_width = 70
+# struct_lit_width = 18
+# struct_variant_width = 35
+# array_width = 60
+# chain_width = 60
+# single_line_if_else_max_width = 50
+
+wrap_comments = false
+format_code_in_doc_comments = false
+comment_width = 100             # Default 80
+normalize_comments = false
+normalize_doc_attributes = false
+format_strings = false
+format_macro_matchers = false
+format_macro_bodies = true
+hex_literal_case = "Preserve"
+empty_item_single_line = true
+struct_lit_single_line = true
+fn_single_line = true           # Default false
+where_single_line = false
+imports_indent = "Block"
+imports_layout = "Mixed"
+imports_granularity = "Module"     # Default "Preserve"
+group_imports = "StdExternalCrate" # Default "Preserve"
+reorder_imports = true
+reorder_modules = true
+reorder_impl_items = false
+type_punctuation_density = "Wide"
+space_before_colon = false
+space_after_colon = true
+spaces_around_ranges = false
+binop_separator = "Front"
+remove_nested_parens = true
+combine_control_expr = true
+overflow_delimited_expr = false
+struct_field_align_threshold = 0
+enum_discrim_align_threshold = 0
+match_arm_blocks = false        # Default true
+match_arm_leading_pipes = "Never"
+force_multiline_blocks = false
+fn_params_layout = "Tall"
+brace_style = "SameLineWhere"
+control_brace_style = "AlwaysSameLine"
+trailing_semicolon = true
+trailing_comma = "Vertical"
+match_block_trailing_comma = false
+blank_lines_upper_bound = 1
+blank_lines_lower_bound = 0
+edition = "2018"
+version = "One"
+inline_attribute_width = 0
+format_generated_files = true
+merge_derives = true
+use_try_shorthand = false
+use_field_init_shorthand = false
+force_explicit_abi = true
+condense_wildcard_suffixes = false
+color = "Auto"
+unstable_features = false
+disable_all_formatting = false
+skip_children = false
+hide_parse_errors = false
+error_on_line_overflow = false
+error_on_unformatted = false
+emit_mode = "Files"
+make_backup = false

--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Implements a buffered encoder.
+//!
+//! This is a low-level module, most uses should be satisfied by the `display` module instead.
+//!
+//! The main type of this module is [`BufEncoder`] which provides buffered hex encoding. Such is
+//! faster than the usual `write!(f, "{02x}", b)?` in a for loop because it reduces dynamic
+//! dispatch and decreases the number of allocations if a `String` is being created.
+
+use core::borrow::Borrow;
+
+pub use out_bytes::OutBytes;
+
+use super::Case;
+
+/// Trait for types that can be soundly converted to `OutBytes`.
+///
+/// To protect the API from future breakage this sealed trait guards which types can be used with
+/// the `Encoder`. Currently it is implemented for byte arrays of various interesting lengths.
+///
+/// ## Safety
+///
+/// This is not `unsafe` yet but the `as_out_bytes` should always return the same reference if the
+/// same reference is supplied. IOW the returned memory address and length should be the same if
+/// the input memory address and length are the same.
+///
+/// If the trait ever becomes `unsafe` this will be required for soundness.
+pub trait AsOutBytes: out_bytes::Sealed {
+    /// Performs the conversion.
+    fn as_out_bytes(&self) -> &OutBytes;
+
+    /// Performs the conversion.
+    fn as_mut_out_bytes(&mut self) -> &mut OutBytes;
+}
+
+/// A buffer with compile-time-known length.
+///
+/// This is essentially `Default + AsOutBytes` but supports lengths 1.41 doesn't.
+pub trait FixedLenBuf: Sized + AsOutBytes {
+    /// Creates an uninitialized buffer.
+    ///
+    /// The current implementtions initialize the buffer with zeroes but it should be treated a
+    /// uninitialized anyway.
+    fn uninit() -> Self;
+}
+
+/// Implements `OutBytes`
+///
+/// This prevents the rest of the crate from accessing the field of `OutBytes`.
+mod out_bytes {
+    use super::AsOutBytes;
+
+    /// A byte buffer that can only be written-into.
+    ///
+    /// You shouldn't concern yourself with this, just call `BufEncoder::new` with your array.
+    ///
+    /// This prepares the API for potential future support of `[MaybeUninit<u8>]`. We don't want to use
+    /// `unsafe` until it's proven to be needed but if it does we have an easy, compatible upgrade
+    /// option.
+    ///
+    /// Warning: `repr(transparent)` is an internal implementation detail and **must not** be
+    /// relied on!
+    #[repr(transparent)]
+    pub struct OutBytes([u8]);
+
+    impl OutBytes {
+        /// Returns the first `len` bytes as initialized.
+        ///
+        /// Not `unsafe` because we don't use `unsafe` (yet).
+        ///
+        /// ## Panics
+        ///
+        /// The method panics if `len` is out of bounds.
+        #[track_caller]
+        pub(crate) fn assume_init(&self, len: usize) -> &[u8] { &self.0[..len] }
+
+        /// Writes given bytes into the buffer.
+        ///
+        /// ## Panics
+        ///
+        /// The method panics if pos is out of bounds or `bytes` don't fit into the buffer.
+        #[track_caller]
+        pub(crate) fn write(&mut self, pos: usize, bytes: &[u8]) {
+            self.0[pos..(pos + bytes.len())].copy_from_slice(bytes);
+        }
+
+        /// Returns the length of the buffer.
+        pub(crate) fn len(&self) -> usize { self.0.len() }
+
+        fn from_bytes(slice: &[u8]) -> &Self {
+            // SAFETY: copied from std
+            // conversion of reference to pointer of the same referred type is always sound,
+            // including in unsized types.
+            // Thanks to repr(transparent) the types have the same layout making the other
+            // conversion sound.
+            // The pointer was just created from a reference that's still alive so dereferencing is
+            // sound.
+            unsafe { &*(slice as *const [u8] as *const Self) }
+        }
+
+        fn from_mut_bytes(slice: &mut [u8]) -> &mut Self {
+            // SAFETY: copied from std
+            // conversion of reference to pointer of the same referred type is always sound,
+            // including in unsized types.
+            // Thanks to repr(transparent) the types have the same layout making the other
+            // conversion sound.
+            // The pointer was just created from a reference that's still alive so dereferencing is
+            // sound.
+            unsafe { &mut *(slice as *mut [u8] as *mut Self) }
+        }
+    }
+
+    macro_rules! impl_from_array {
+        ($($len:expr),* $(,)?) => {
+            $(
+                impl super::FixedLenBuf for [u8; $len] {
+                    fn uninit() -> Self {
+                        [0u8; $len]
+                    }
+                }
+
+                impl AsOutBytes for [u8; $len] {
+                    fn as_out_bytes(&self) -> &OutBytes {
+                        OutBytes::from_bytes(self)
+                    }
+
+                    fn as_mut_out_bytes(&mut self) -> &mut OutBytes {
+                        OutBytes::from_mut_bytes(self)
+                    }
+                }
+
+                impl Sealed for [u8; $len] {}
+
+                impl<'a> super::super::display::DisplayHex for &'a [u8; $len / 2] {
+                    type Display = super::super::display::DisplayArray<core::slice::Iter<'a, u8>, [u8; $len]>;
+                    fn as_hex(self) -> Self::Display {
+                        super::super::display::DisplayArray::new(self.iter())
+                    }
+
+                    fn hex_reserve_suggestion(self) -> usize {
+                        $len
+                    }
+                }
+            )*
+        }
+    }
+
+    impl<T: AsOutBytes + ?Sized> AsOutBytes for &'_ mut T {
+        fn as_out_bytes(&self) -> &OutBytes { (**self).as_out_bytes() }
+
+        fn as_mut_out_bytes(&mut self) -> &mut OutBytes { (**self).as_mut_out_bytes() }
+    }
+
+    impl<T: AsOutBytes + ?Sized> Sealed for &'_ mut T {}
+
+    impl AsOutBytes for OutBytes {
+        fn as_out_bytes(&self) -> &OutBytes { self }
+
+        fn as_mut_out_bytes(&mut self) -> &mut OutBytes { self }
+    }
+
+    impl Sealed for OutBytes {}
+
+    // As a sanity check we only provide conversions for even, non-empty arrays.
+    // Weird lengths 66 and 130 are provided for serialized public keys.
+    impl_from_array!(
+        2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 40, 64, 66, 128, 130, 256, 512,
+        1024, 2048, 4096, 8192
+    );
+
+    /// Prevents outside crates from implementing the trait
+    pub trait Sealed {}
+}
+
+/// Hex-encodes bytes into the provided buffer.
+///
+/// This is an important building block for fast hex-encoding. Because string writing tools
+/// provided by `core::fmt` involve dynamic dispatch and don't allow reserving capacity in strings
+/// buffering the hex and then formatting it is significantly faster.
+pub struct BufEncoder<T: AsOutBytes> {
+    buf: T,
+    pos: usize,
+}
+
+impl<T: AsOutBytes> BufEncoder<T> {
+    /// Creates an empty `BufEncoder`.
+    ///
+    /// This is usually used with uninitialized (zeroed) byte array allocated on stack.
+    /// This can only be constructed with an even-length, non-empty array.
+    #[inline]
+    pub fn new(buf: T) -> Self { BufEncoder { buf, pos: 0 } }
+
+    /// Encodes `byte` as hex in given `case` and appends it to the buffer.
+    ///
+    /// ## Panics
+    ///
+    /// The method panics if the buffer is full.
+    #[inline]
+    #[track_caller]
+    pub fn put_byte(&mut self, byte: u8, case: Case) {
+        self.buf.as_mut_out_bytes().write(self.pos, &super::byte_to_hex(byte, case.table()));
+        self.pos += 2;
+    }
+
+    /// Encodes `bytes` as hex in given `case` and appends them to the buffer.
+    ///
+    /// ## Panics
+    ///
+    /// The method panics if the bytes wouldn't fit the buffer.
+    #[inline]
+    #[track_caller]
+    pub fn put_bytes<I>(&mut self, bytes: I, case: Case)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<u8>,
+    {
+        self.put_bytes_inner(bytes.into_iter(), case)
+    }
+
+    #[inline]
+    #[track_caller]
+    fn put_bytes_inner<I>(&mut self, bytes: I, case: Case)
+    where
+        I: Iterator,
+        I::Item: Borrow<u8>,
+    {
+        // May give the compiler better optimization opportunity
+        if let Some(max) = bytes.size_hint().1 {
+            assert!(max <= self.space_remaining());
+        }
+        for byte in bytes {
+            self.put_byte(*byte.borrow(), case);
+        }
+    }
+
+    /// Encodes as many `bytes` as fit into the buffer as hex and return the remainder.
+    ///
+    /// This method works just like `put_bytes` but instead of panicking it returns the unwritten
+    /// bytes. The method returns an empty slice if all bytes were written
+    #[must_use = "this may write only part of the input buffer"]
+    #[inline]
+    #[track_caller]
+    pub fn put_bytes_min<'a>(&mut self, bytes: &'a [u8], case: Case) -> &'a [u8] {
+        let to_write = self.space_remaining().min(bytes.len());
+        self.put_bytes(&bytes[..to_write], case);
+        &bytes[to_write..]
+    }
+
+    /// Returns true if no more bytes can be written into the buffer.
+    #[inline]
+    pub fn is_full(&self) -> bool { self.pos == self.buf.as_out_bytes().len() }
+
+    /// Returns the written bytes as a hex `str`.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        core::str::from_utf8(self.buf.as_out_bytes().assume_init(self.pos))
+            .expect("we only write ASCII")
+    }
+
+    /// Resets the buffer to become empty.
+    #[inline]
+    pub fn clear(&mut self) { self.pos = 0; }
+
+    /// How many bytes can be written to this buffer.
+    ///
+    /// Note that this returns the number of bytes before encoding, not number of hex digits.
+    #[inline]
+    pub fn space_remaining(&self) -> usize { (self.buf.as_out_bytes().len() - self.pos) / 2 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let mut buf = [0u8; 2];
+        let encoder = BufEncoder::new(&mut buf);
+        assert_eq!(encoder.as_str(), "");
+        assert!(!encoder.is_full());
+    }
+
+    #[test]
+    fn single_byte_exact_buf() {
+        let mut buf = [0u8; 2];
+        let mut encoder = BufEncoder::new(&mut buf);
+        assert_eq!(encoder.space_remaining(), 1);
+        encoder.put_byte(42, Case::Lower);
+        assert_eq!(encoder.as_str(), "2a");
+        assert_eq!(encoder.space_remaining(), 0);
+        assert!(encoder.is_full());
+        encoder.clear();
+        assert_eq!(encoder.space_remaining(), 1);
+        assert!(!encoder.is_full());
+        encoder.put_byte(42, Case::Upper);
+        assert_eq!(encoder.as_str(), "2A");
+        assert_eq!(encoder.space_remaining(), 0);
+        assert!(encoder.is_full());
+    }
+
+    #[test]
+    fn single_byte_oversized_buf() {
+        let mut buf = [0u8; 4];
+        let mut encoder = BufEncoder::new(&mut buf);
+        assert_eq!(encoder.space_remaining(), 2);
+        encoder.put_byte(42, Case::Lower);
+        assert_eq!(encoder.space_remaining(), 1);
+        assert_eq!(encoder.as_str(), "2a");
+        assert!(!encoder.is_full());
+        encoder.clear();
+        assert_eq!(encoder.space_remaining(), 2);
+        encoder.put_byte(42, Case::Upper);
+        assert_eq!(encoder.as_str(), "2A");
+        assert_eq!(encoder.space_remaining(), 1);
+        assert!(!encoder.is_full());
+    }
+
+    #[test]
+    fn two_bytes() {
+        let mut buf = [0u8; 4];
+        let mut encoder = BufEncoder::new(&mut buf);
+        encoder.put_byte(42, Case::Lower);
+        assert_eq!(encoder.space_remaining(), 1);
+        encoder.put_byte(255, Case::Lower);
+        assert_eq!(encoder.space_remaining(), 0);
+        assert_eq!(encoder.as_str(), "2aff");
+        assert!(encoder.is_full());
+        encoder.clear();
+        assert!(!encoder.is_full());
+        encoder.put_byte(42, Case::Upper);
+        encoder.put_byte(255, Case::Upper);
+        assert_eq!(encoder.as_str(), "2AFF");
+        assert!(encoder.is_full());
+    }
+
+    #[test]
+    fn put_bytes_min() {
+        let mut buf = [0u8; 2];
+        let mut encoder = BufEncoder::new(&mut buf);
+        let remainder = encoder.put_bytes_min(b"", Case::Lower);
+        assert_eq!(remainder, b"");
+        assert_eq!(encoder.as_str(), "");
+        let remainder = encoder.put_bytes_min(b"*", Case::Lower);
+        assert_eq!(remainder, b"");
+        assert_eq!(encoder.as_str(), "2a");
+        encoder.clear();
+        let remainder = encoder.put_bytes_min(&[42, 255], Case::Lower);
+        assert_eq!(remainder, &[255]);
+        assert_eq!(encoder.as_str(), "2a");
+    }
+
+    #[test]
+    fn same_as_fmt() {
+        use core::fmt::{self, Write};
+
+        struct Writer {
+            buf: [u8; 2],
+            pos: usize,
+        }
+
+        impl Writer {
+            fn as_str(&self) -> &str { core::str::from_utf8(&self.buf[..self.pos]).unwrap() }
+        }
+
+        impl Write for Writer {
+            fn write_str(&mut self, s: &str) -> fmt::Result {
+                assert!(self.pos <= 2);
+                if s.len() > 2 - self.pos {
+                    Err(fmt::Error)
+                } else {
+                    self.buf[self.pos..(self.pos + s.len())].copy_from_slice(s.as_bytes());
+                    self.pos += s.len();
+                    Ok(())
+                }
+            }
+        }
+
+        let mut writer = Writer { buf: [0u8; 2], pos: 0 };
+        let mut buf = [0u8; 2];
+        let mut encoder = BufEncoder::new(&mut buf);
+
+        for i in 0..=255 {
+            write!(writer, "{:02x}", i).unwrap();
+            encoder.put_byte(i, Case::Lower);
+            assert_eq!(encoder.as_str(), writer.as_str());
+            writer.pos = 0;
+            encoder.clear();
+        }
+        for i in 0..=255 {
+            write!(writer, "{:02X}", i).unwrap();
+            encoder.put_byte(i, Case::Upper);
+            assert_eq!(encoder.as_str(), writer.as_str());
+            writer.pos = 0;
+            encoder.clear();
+        }
+    }
+}

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Helpers for displaying bytes as hex strings.
+//!
+//! This module provides a trait for displaying things as hex as well as an implementation for
+//! `&[u8]`.
+
+use core::borrow::Borrow;
+use core::fmt;
+
+use super::Case;
+use crate::buf_encoder::{BufEncoder, FixedLenBuf, OutBytes};
+#[cfg(feature = "alloc")]
+use crate::prelude::*;
+
+/// Extension trait for types that can be displayed as hex.
+///
+/// Types that have a single, obvious text representation being hex should **not** implement this
+/// trait and simply implement `Display` instead.
+///
+/// This trait should be generally implemented for references only. We would prefer to use GAT but
+/// that is beyond our MSRV. As a lint we require the `IsRef` trait which is implemented for all
+/// references.
+pub trait DisplayHex: Copy + sealed::IsRef {
+    /// The type providing [`fmt::Display`] implementation.
+    ///
+    /// This is usually a wrapper type holding a reference to `Self`.
+    type Display: fmt::LowerHex + fmt::UpperHex;
+
+    /// Display `Self` as a continuous sequence of ASCII hex chars.
+    fn as_hex(self) -> Self::Display;
+
+    /// Create a lower-hex-encoded string.
+    ///
+    /// A shorthand for `to_hex_string(Case::Lower)`, so that `Case` doesn't need to be imported.
+    ///
+    /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
+    #[cfg(feature = "alloc")]
+    fn to_lower_hex_string(self) -> String { self.to_hex_string(Case::Lower) }
+
+    /// Create an upper-hex-encoded string.
+    ///
+    /// A shorthand for `to_hex_string(Case::Upper)`, so that `Case` doesn't need to be imported.
+    ///
+    /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
+    #[cfg(feature = "alloc")]
+    fn to_upper_hex_string(self) -> String { self.to_hex_string(Case::Upper) }
+
+    /// Create a hex-encoded string.
+    ///
+    /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
+    #[cfg(feature = "alloc")]
+    fn to_hex_string(self, case: Case) -> String {
+        let mut string = String::new();
+        self.append_hex_to_string(case, &mut string);
+        string
+    }
+
+    /// Appends hex-encoded content to an existing `String`.
+    ///
+    /// This may be faster than `write!(string, "{:x}", self.display_hex())` because it uses
+    /// `reserve_sugggestion`.
+    #[cfg(feature = "alloc")]
+    fn append_hex_to_string(self, case: Case, string: &mut String) {
+        use fmt::Write;
+
+        string.reserve(self.hex_reserve_suggestion());
+        match case {
+            Case::Lower => write!(string, "{:x}", self.as_hex()),
+            Case::Upper => write!(string, "{:X}", self.as_hex()),
+        }
+        .unwrap_or_else(|_| {
+            let name = core::any::type_name::<Self::Display>();
+            // We don't expect `std` to ever be buggy, so the bug is most likely in the `Display`
+            // impl of `Self::Display`.
+            panic!("The implementation of Display for {} returned an error when it shouldn't", name)
+        })
+    }
+
+    /// Hints how much bytes to reserve when creating a `String`.
+    ///
+    /// Implementors that know the number of produced bytes upfront should override this.
+    /// Defaults to 0.
+    ///
+    // We prefix the name with `hex_` to avoid potential collision with other methods.
+    fn hex_reserve_suggestion(self) -> usize { 0 }
+}
+
+mod sealed {
+    /// Trait marking a shared reference.
+    pub trait IsRef: Copy {}
+
+    impl<T: ?Sized> IsRef for &'_ T {}
+}
+
+impl<'a> DisplayHex for &'a [u8] {
+    type Display = DisplayByteSlice<'a>;
+
+    #[inline]
+    fn as_hex(self) -> Self::Display { DisplayByteSlice { bytes: self } }
+
+    #[inline]
+    fn hex_reserve_suggestion(self) -> usize {
+        // Since the string wouldn't fit into address space if this overflows (actually even for
+        // smaller amounts) it's better to panic right away. It should also give the optimizer
+        // better opportunities.
+        self.len().checked_mul(2).expect("the string wouldn't fit into address space")
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> DisplayHex for &'a alloc::vec::Vec<u8> {
+    type Display = DisplayByteSlice<'a>;
+
+    #[inline]
+    fn as_hex(self) -> Self::Display { DisplayByteSlice { bytes: self } }
+
+    #[inline]
+    fn hex_reserve_suggestion(self) -> usize {
+        // Since the string wouldn't fit into address space if this overflows (actually even for
+        // smaller amounts) it's better to panic right away. It should also give the optimizer
+        // better opportunities.
+        self.len().checked_mul(2).expect("the string wouldn't fit into address space")
+    }
+}
+
+/// Displays byte slice as hex.
+///
+/// Created by [`<&[u8] as DisplayHex>::as_hex`](DisplayHex::as_hex).
+pub struct DisplayByteSlice<'a> {
+    // pub because we want to keep lengths in sync
+    pub(crate) bytes: &'a [u8],
+}
+
+impl<'a> DisplayByteSlice<'a> {
+    fn display(&self, f: &mut fmt::Formatter, case: Case) -> fmt::Result {
+        let mut buf = [0u8; 1024];
+        let mut encoder = BufEncoder::new(&mut buf);
+
+        let mut chunks = self.bytes.chunks_exact(512);
+        for chunk in &mut chunks {
+            encoder.put_bytes(chunk, case);
+            f.write_str(encoder.as_str())?;
+            encoder.clear();
+        }
+        encoder.put_bytes(chunks.remainder(), case);
+        f.write_str(encoder.as_str())
+    }
+}
+
+impl<'a> fmt::LowerHex for DisplayByteSlice<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Lower) }
+}
+
+impl<'a> fmt::UpperHex for DisplayByteSlice<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Upper) }
+}
+
+/// Displays byte array as hex.
+///
+/// Created by [`<&[u8; LEN] as DisplayHex>::as_hex`](DisplayHex::as_hex).
+pub struct DisplayArray<A: Clone + IntoIterator, B: FixedLenBuf>
+where
+    A::Item: Borrow<u8>,
+{
+    array: A,
+    _buffer_marker: core::marker::PhantomData<B>,
+}
+
+impl<A: Clone + IntoIterator, B: FixedLenBuf> DisplayArray<A, B>
+where
+    A::Item: Borrow<u8>,
+{
+    /// Creates the wrapper.
+    pub fn new(array: A) -> Self { DisplayArray { array, _buffer_marker: Default::default() } }
+
+    fn display(&self, f: &mut fmt::Formatter, case: Case) -> fmt::Result {
+        let mut buf = B::uninit();
+        let mut encoder = BufEncoder::new(&mut buf);
+        encoder.put_bytes(self.array.clone(), case);
+        f.pad_integral(true, "0x", encoder.as_str())
+    }
+}
+
+impl<A: Clone + IntoIterator, B: FixedLenBuf> fmt::LowerHex for DisplayArray<A, B>
+where
+    A::Item: Borrow<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Lower) }
+}
+
+impl<A: Clone + IntoIterator, B: FixedLenBuf> fmt::UpperHex for DisplayArray<A, B>
+where
+    A::Item: Borrow<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Upper) }
+}
+
+/// Format known-length array as hex.
+///
+/// This supports all formatting options of formatter and may be faster than calling
+/// `display_as_hex()` on an arbitrary `&[u8]`. Note that the implementation intentionally keeps
+/// leading zeros even when not requested. This is designed to display values such as hashes and
+/// keys and removing leading zeros would be confusing.
+///
+/// ## Parameters
+///
+/// * `$formatter` - a [`fmt::Formatter`].
+/// * `$len` known length of `$bytes`, must be a const expression.
+/// * `$bytes` - bytes to be encoded, most likely a reference to an array.
+/// * `$case` - value of type [`Case`] determining whether to format as lower or upper case.
+///
+/// ## Panics
+///
+/// This macro panics if `$len` is not equal to `$bytes.len()`. It also fails to compile if `$len`
+/// is more than half of `usize::MAX`.
+#[macro_export]
+macro_rules! fmt_hex_exact {
+    ($formatter:expr, $len:expr, $bytes:expr, $case:expr) => {{
+        // statically check $len
+        #[allow(deprecated)]
+        const _: () = [()][($len > usize::max_value() / 2) as usize];
+        assert_eq!($bytes.len(), $len);
+        let mut buf = [0u8; $len * 2];
+        let buf = $crate::buf_encoder::AsOutBytes::as_mut_out_bytes(&mut buf);
+        $crate::display::fmt_hex_exact_fn($formatter, buf, $bytes, $case)
+    }};
+}
+pub use fmt_hex_exact;
+
+// Implementation detail of `write_hex_exact` macro to de-duplicate the code
+#[doc(hidden)]
+#[inline]
+pub fn fmt_hex_exact_fn<I>(
+    f: &mut fmt::Formatter,
+    buf: &mut OutBytes,
+    bytes: I,
+    case: Case,
+) -> fmt::Result
+where
+    I: IntoIterator,
+    I::Item: Borrow<u8>,
+{
+    let mut encoder = BufEncoder::new(buf);
+    encoder.put_bytes(bytes, case);
+    f.pad_integral(true, "0x", encoder.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "alloc")]
+    use super::*;
+
+    #[cfg(feature = "alloc")]
+    mod alloc {
+        use super::*;
+
+        fn check_encoding(bytes: &[u8]) {
+            use core::fmt::Write;
+
+            let s1 = bytes.to_lower_hex_string();
+            let mut s2 = String::with_capacity(bytes.len() * 2);
+            for b in bytes {
+                write!(s2, "{:02x}", b).unwrap();
+            }
+            assert_eq!(s1, s2);
+        }
+
+        #[test]
+        fn empty() { check_encoding(b""); }
+
+        #[test]
+        fn single() { check_encoding(b"*"); }
+
+        #[test]
+        fn two() { check_encoding(b"*x"); }
+
+        #[test]
+        fn just_below_boundary() { check_encoding(&[42; 512]); }
+
+        #[test]
+        fn just_above_boundary() { check_encoding(&[42; 513]); }
+
+        #[test]
+        fn just_above_double_boundary() { check_encoding(&[42; 1025]); }
+
+        #[test]
+        fn fmt_exact_macro() {
+            use crate::alloc::string::ToString;
+
+            struct Dummy([u8; 32]);
+
+            impl fmt::Display for Dummy {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    fmt_hex_exact!(f, 32, &self.0, Case::Lower)
+                }
+            }
+
+            assert_eq!(Dummy([42; 32]).to_string(), "2a".repeat(32));
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Hex encoding and decoding.
+//!
+//! General purpose hex encoding/decoding library with a conservative MSRV and dependency policy.
+//!
+//! ## Basic Usage
+//! ```
+//! # #[cfg(feature = "alloc")] {
+//! // Use the `package` key to improve import ergonomics (`hex` instead of `hex-conservative`).
+//! // hex = { package = "hex-conservative", version = "*" }
+//! # use hex_conservative as hex; // No need for this if using `package` as above.
+//! use hex::{DisplayHex, FromHex};
+//!
+//! // Decode an arbitrary length hex string into a vector.
+//! let v = Vec::from_hex("deadbeef").expect("valid hex digits");
+//! // Or a known length hex string into a fixed size array.
+//! let a = <[u8; 4]>::from_hex("deadbeef").expect("valid length and valid hex digits");
+//! // We support `LowerHex` and `UpperHex` out of the box for `[u8]` slices.
+//! println!("An array as lower hex: {:x}", a.as_hex());
+//! // And for vecs since `Vec` derefs to byte slice.
+//! println!("A vector as upper hex: {:X}", v.as_hex());
+//! # }
+//! ```
+
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+// Experimental features we need.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+// Coding conventions
+#![warn(missing_docs)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+pub mod buf_encoder;
+pub mod display;
+pub mod parse;
+
+pub use display::DisplayHex;
+pub use parse::{Error, FromHex};
+
+/// Reexports of extension traits.
+pub mod exts {
+    pub use super::display::DisplayHex;
+    pub use super::parse::FromHex;
+}
+
+/// Mainly reexports based on features.
+pub(crate) mod prelude {
+    #[cfg(feature = "alloc")]
+    pub(crate) use alloc::string::String;
+}
+
+/// Possible case of hex.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum Case {
+    /// Produce lower-case chars (`[0-9a-f]`).
+    ///
+    /// This is the default.
+    Lower,
+
+    /// Produce upper-case chars (`[0-9A-F]`).
+    Upper,
+}
+
+impl Default for Case {
+    fn default() -> Self { Case::Lower }
+}
+
+impl Case {
+    /// Returns the encoding table.
+    ///
+    /// The returned table may only contain displayable ASCII chars.
+    #[inline]
+    #[rustfmt::skip]
+    pub(crate) fn table(self) -> &'static [u8; 16] {
+        static LOWER: [u8; 16] = [b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b', b'c', b'd', b'e', b'f'];
+        static UPPER: [u8; 16] = [b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'A', b'B', b'C', b'D', b'E', b'F'];
+
+        match self {
+            Case::Lower => &LOWER,
+            Case::Upper => &UPPER,
+        }
+    }
+}
+
+/// Encodes single byte as two ASCII chars using the given table.
+///
+/// The function guarantees only returning values from the provided table.
+#[inline]
+pub(crate) fn byte_to_hex(byte: u8, table: &[u8; 16]) -> [u8; 2] {
+    [table[usize::from(byte.wrapping_shr(4))], table[usize::from(byte & 0x0F)]]
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Hex encoding and decoding.
+
+use core::{fmt, str};
+#[cfg(feature = "std")]
+use std::io;
+
+#[cfg(all(feature = "core2", not(feature = "std")))]
+use core2::io;
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use crate::alloc::vec::Vec;
+
+/// Hex decoding error.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Error {
+    /// Non-hexadecimal character.
+    InvalidChar(u8),
+    /// Purported hex string had odd length.
+    OddLengthString(usize),
+    /// Tried to parse fixed-length hash from a string with the wrong type (expected, got).
+    InvalidLength(usize, usize),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::InvalidChar(ch) => write!(f, "invalid hex character {}", ch),
+            Error::OddLengthString(ell) => write!(f, "odd hex string length {}", ell),
+            Error::InvalidLength(ell, ell2) =>
+                write!(f, "bad hex string length {} (expected {})", ell2, ell),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::Error::*;
+
+        match self {
+            InvalidChar(_) | OddLengthString(_) | InvalidLength(_, _) => None,
+        }
+    }
+}
+
+/// Trait for objects that can be deserialized from hex strings.
+pub trait FromHex: Sized {
+    /// Produces an object from a byte iterator.
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator;
+
+    /// Produces an object from a hex string.
+    fn from_hex(s: &str) -> Result<Self, Error> { Self::from_byte_iter(HexIterator::new(s)?) }
+}
+
+/// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
+pub struct HexIterator<'a> {
+    /// The `Bytes` iterator whose next two bytes will be decoded to yield
+    /// the next byte.
+    iter: str::Bytes<'a>,
+}
+
+impl<'a> HexIterator<'a> {
+    /// Constructs a new `HexIterator` from a string slice.
+    ///
+    /// # Errors
+    ///
+    /// If the input string is of odd length.
+    pub fn new(s: &'a str) -> Result<HexIterator<'a>, Error> {
+        if s.len() % 2 != 0 {
+            Err(Error::OddLengthString(s.len()))
+        } else {
+            Ok(HexIterator { iter: s.bytes() })
+        }
+    }
+}
+
+fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, Error> {
+    let hih = (hi as char).to_digit(16).ok_or(Error::InvalidChar(hi))?;
+    let loh = (lo as char).to_digit(16).ok_or(Error::InvalidChar(lo))?;
+
+    let ret = (hih << 4) + loh;
+    Ok(ret as u8)
+}
+
+impl<'a> Iterator for HexIterator<'a> {
+    type Item = Result<u8, Error>;
+
+    fn next(&mut self) -> Option<Result<u8, Error>> {
+        let hi = self.iter.next()?;
+        let lo = self.iter.next().unwrap();
+        Some(chars_to_hex(hi, lo))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.iter.size_hint();
+        (min / 2, max.map(|x| x / 2))
+    }
+}
+
+#[cfg(any(feature = "std", feature = "core2"))]
+impl<'a> io::Read for HexIterator<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut bytes_read = 0usize;
+        for dst in buf {
+            match self.next() {
+                Some(Ok(src)) => {
+                    *dst = src;
+                    bytes_read += 1;
+                }
+                _ => break,
+            }
+        }
+        Ok(bytes_read)
+    }
+}
+
+impl<'a> DoubleEndedIterator for HexIterator<'a> {
+    fn next_back(&mut self) -> Option<Result<u8, Error>> {
+        let lo = self.iter.next_back()?;
+        let hi = self.iter.next_back().unwrap();
+        Some(chars_to_hex(hi, lo))
+    }
+}
+
+impl<'a> ExactSizeIterator for HexIterator<'a> {}
+
+#[cfg(any(test, feature = "std", feature = "alloc"))]
+impl FromHex for Vec<u8> {
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
+    {
+        iter.collect()
+    }
+}
+
+macro_rules! impl_fromhex_array {
+    ($len:expr) => {
+        impl FromHex for [u8; $len] {
+            fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+            where
+                I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
+            {
+                if iter.len() == $len {
+                    let mut ret = [0; $len];
+                    for (n, byte) in iter.enumerate() {
+                        ret[n] = byte?;
+                    }
+                    Ok(ret)
+                } else {
+                    Err(Error::InvalidLength(2 * $len, 2 * iter.len()))
+                }
+            }
+        }
+    };
+}
+
+impl_fromhex_array!(2);
+impl_fromhex_array!(4);
+impl_fromhex_array!(6);
+impl_fromhex_array!(8);
+impl_fromhex_array!(10);
+impl_fromhex_array!(12);
+impl_fromhex_array!(14);
+impl_fromhex_array!(16);
+impl_fromhex_array!(20);
+impl_fromhex_array!(24);
+impl_fromhex_array!(28);
+impl_fromhex_array!(32);
+impl_fromhex_array!(33);
+impl_fromhex_array!(64);
+impl_fromhex_array!(65);
+impl_fromhex_array!(128);
+impl_fromhex_array!(256);
+impl_fromhex_array!(384);
+impl_fromhex_array!(512);
+
+#[cfg(test)]
+#[cfg(feature = "alloc")]
+mod tests {
+    use super::*;
+    use crate::display::DisplayHex;
+
+    #[test]
+    fn hex_roundtrip() {
+        let expected = "0123456789abcdef";
+        let expected_up = "0123456789ABCDEF";
+
+        let parse: Vec<u8> = FromHex::from_hex(expected).expect("parse lowercase string");
+        assert_eq!(parse, vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        let ser = parse.to_lower_hex_string();
+        assert_eq!(ser, expected);
+
+        let parse: Vec<u8> = FromHex::from_hex(expected_up).expect("parse uppercase string");
+        assert_eq!(parse, vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        let ser = parse.to_lower_hex_string();
+        assert_eq!(ser, expected);
+
+        let parse: [u8; 8] = FromHex::from_hex(expected_up).expect("parse uppercase string");
+        assert_eq!(parse, [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        let ser = parse.to_lower_hex_string();
+        assert_eq!(ser, expected);
+    }
+
+    #[test]
+    fn hex_error() {
+        let oddlen = "0123456789abcdef0";
+        let badchar1 = "Z123456789abcdef";
+        let badchar2 = "012Y456789abcdeb";
+        let badchar3 = "«23456789abcdef";
+
+        assert_eq!(Vec::<u8>::from_hex(oddlen), Err(Error::OddLengthString(17)));
+        assert_eq!(<[u8; 4]>::from_hex(oddlen), Err(Error::OddLengthString(17)));
+        assert_eq!(<[u8; 8]>::from_hex(oddlen), Err(Error::OddLengthString(17)));
+        assert_eq!(Vec::<u8>::from_hex(badchar1), Err(Error::InvalidChar(b'Z')));
+        assert_eq!(Vec::<u8>::from_hex(badchar2), Err(Error::InvalidChar(b'Y')));
+        assert_eq!(Vec::<u8>::from_hex(badchar3), Err(Error::InvalidChar(194)));
+    }
+}


### PR DESCRIPTION
Import the following files
    
- `buf_encoder.rs`: from `internals/src/hex/buf_encoder.rs`
- `display.rs`: from `internals/src/hex/display.rs`
- `mod.rs`: from `internals/src/hex/mod.rs`
- `parse.rs`: from `hashes/src/hex.rs`
    
The files above can be diffed to see the changes introduced, which should be minimal.

Includes all standard infrastructure: GitHub actions, rustfmt, clippy, githooks

Does not include lock files (minimal and recent). I had a go at this but we only have two dependencies (`core2` direct, and `memchr` transient) so it doesn't seem necessary. 
