### PR TITLE
Remove call to max_value

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -219,7 +219,7 @@ macro_rules! fmt_hex_exact {
     ($formatter:expr, $len:expr, $bytes:expr, $case:expr) => {{
         // statically check $len
         #[allow(deprecated)]
-        const _: () = [()][($len > usize::max_value() / 2) as usize];
+        const _: () = [()][($len > usize::MAX / 2) as usize];
         assert_eq!($bytes.len(), $len);
         let mut buf = [0u8; $len * 2];
         let buf = $crate::buf_encoder::AsOutBytes::as_mut_out_bytes(&mut buf);


### PR DESCRIPTION
The new MSRV (1.48.0) uses associated consts MAX/MIN instead of functions, use the const instead of making a function call.