### PR TITLE
Add a mixed case example/test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,13 @@
 //! println!("An array as lower hex: {:x}", a.as_hex());
 //! // And for vecs since `Vec` derefs to byte slice.
 //! println!("A vector as upper hex: {:X}", v.as_hex());
+//!
+//! // Please note, mixed case strings will still parse successfully but we only
+//! // support displaying hex in a single case.
+//! assert_eq!(
+//!     Vec::from_hex("dEaDbEeF").expect("valid mixed case hex digits"),
+//!     Vec::from_hex("deadbeef").expect("valid hex digits"),
+//! );
 //! # }
 //! ```
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -220,4 +220,15 @@ mod tests {
         assert_eq!(Vec::<u8>::from_hex(badchar2), Err(Error::InvalidChar(b'Y')));
         assert_eq!(Vec::<u8>::from_hex(badchar3), Err(Error::InvalidChar(194)));
     }
+
+    #[test]
+    fn mixed_case() {
+        let s = "DEADbeef0123";
+        let want_lower = "deadbeef0123";
+        let want_upper = "DEADBEEF0123";
+
+        let v = Vec::<u8>::from_hex(s).expect("valid hex");
+        assert_eq!(format!("{:x}", v.as_hex()), want_lower);
+        assert_eq!(format!("{:X}", v.as_hex()), want_upper);
+    }
 }


### PR DESCRIPTION
This library can parse hex strings of either case. Also we do not care if a hex string contains a mix of uppercase and lowercase, however we only output in a single case. This means mixed case strings do not roundtrip.

Add an example and a unit test that shows parsing of mixed case hex strings.