### PR TITLE
Remove rustfmt ignores

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,12 +1,4 @@
-# Eventually this shoud be: ignore = []
-ignore = [
-       "bitcoin/src/blockdata",
-       "bitcoin/src/consensus",
-       "bitcoin/src/crypto",
-       "bitcoin/src/psbt",
-       "bitcoin/src/util",
-       "hashes",
-]
+ignore = []
 
 hard_tabs = false
 tab_spaces = 4


### PR DESCRIPTION
This is a cut'n pasta mistake from when I copied the rustfmt config file from `rust-bitcoin`.