### PR TITLE
Improve exact sized iter impl on `HexToBytesIter`

### DIFF
--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -1,15 +1,15 @@
-//! Demonstrate basic hexadecimal encoding and decoding.
+//! Demonstrate custom hexadecimal encoding and decoding.
 //!
 //! For basic encoding and decoding see crate level rustdoc in `lib.rs`.
 
 use std::fmt;
 use std::str::FromStr;
 
-use hex_conservative::{fmt_hex_exact, Case, Error, FromHex};
+use hex_conservative::{fmt_hex_exact, Case, FromHex, HexToArrayError, HexToBytesError};
 
 fn main() {
     let s = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
-    let hexy = Hexy::from_hex(s).expect("valid hex digits");
+    let hexy = Hexy::from_hex(s).expect("the correct number of valid hex digits");
     let display = format!("{}", hexy);
 
     assert_eq!(display, s);
@@ -34,7 +34,7 @@ impl fmt::Display for Hexy {
 }
 
 impl FromStr for Hexy {
-    type Err = Error;
+    type Err = HexToArrayError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> { Hexy::from_hex(s) }
 }
@@ -60,9 +60,11 @@ impl fmt::UpperHex for Hexy {
 // And use a fixed size array to convert from hex.
 
 impl FromHex for Hexy {
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+    type Error = HexToArrayError;
+
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
     where
-        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         // Errors if the iterator is the wrong length.
         let a = <[u8; 32] as FromHex>::from_byte_iter(iter)?;

--- a/fuzz/fuzz_targets/hex.rs
+++ b/fuzz/fuzz_targets/hex.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use hex::{fmt_hex_exact, Case, Error, FromHex};
+use hex::{fmt_hex_exact, Case, FromHex, HexToArrayError, HexToBytesError};
 use honggfuzz::fuzz;
 
 const LEN: usize = 32; // Arbitrary amount of data.
@@ -22,7 +22,7 @@ impl fmt::Display for Hexy {
 }
 
 impl FromStr for Hexy {
-    type Err = Error;
+    type Err = HexToArrayError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> { Hexy::from_hex(s) }
 }
@@ -40,9 +40,11 @@ impl fmt::UpperHex for Hexy {
 }
 
 impl FromHex for Hexy {
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+    type Error = HexToArrayError;
+
+    fn from_byte_iter<I>(iter: I) -> Result<Self, HexToArrayError>
     where
-        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         // Errors if the iterator is the wrong length.
         let a = <[u8; 32] as FromHex>::from_byte_iter(iter)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: CC0-1.0
+
+/// Formats error.
+///
+/// If `std` feature is OFF appends error source (delimited by `: `). We do this because
+/// `e.source()` is only available in std builds, without this macro the error source is lost for
+/// no-std builds.
+#[macro_export]
+macro_rules! write_err {
+    ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
+        {
+            #[cfg(feature = "std")]
+            {
+                let _ = &$source;   // Prevents clippy warnings.
+                write!($writer, $string $(, $args)*)
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                write!($writer, concat!($string, ": {}") $(, $args)*, $source)
+            }
+        }
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Iterator that converts hex to bytes.
+
+use core::str;
+#[cfg(feature = "std")]
+use std::io;
+
+#[cfg(all(feature = "core2", not(feature = "std")))]
+use core2::io;
+
+use crate::parse::HexToBytesError;
+
+/// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
+pub struct HexToBytesIter<'a> {
+    /// The `Bytes` iterator whose next two bytes will be decoded to yield
+    /// the next byte.
+    iter: str::Bytes<'a>,
+}
+
+impl<'a> HexToBytesIter<'a> {
+    /// Constructs a new `HexToBytesIter` from a string slice.
+    ///
+    /// # Errors
+    ///
+    /// If the input string is of odd length.
+    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, HexToBytesError> {
+        if s.len() % 2 != 0 {
+            Err(HexToBytesError::OddLengthString(s.len()))
+        } else {
+            Ok(HexToBytesIter { iter: s.bytes() })
+        }
+    }
+}
+
+fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
+    let hih = (hi as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(hi))?;
+    let loh = (lo as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(lo))?;
+
+    let ret = (hih << 4) + loh;
+    Ok(ret as u8)
+}
+
+impl<'a> Iterator for HexToBytesIter<'a> {
+    type Item = Result<u8, HexToBytesError>;
+
+    fn next(&mut self) -> Option<Result<u8, HexToBytesError>> {
+        let hi = self.iter.next()?;
+        let lo = self.iter.next().unwrap();
+        Some(chars_to_hex(hi, lo))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.iter.size_hint();
+        (min / 2, max.map(|x| x / 2))
+    }
+}
+
+#[cfg(any(feature = "std", feature = "core2"))]
+impl<'a> io::Read for HexToBytesIter<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut bytes_read = 0usize;
+        for dst in buf {
+            match self.next() {
+                Some(Ok(src)) => {
+                    *dst = src;
+                    bytes_read += 1;
+                }
+                _ => break,
+            }
+        }
+        Ok(bytes_read)
+    }
+}
+
+impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
+    fn next_back(&mut self) -> Option<Result<u8, HexToBytesError>> {
+        let lo = self.iter.next_back()?;
+        let hi = self.iter.next_back().unwrap();
+        Some(chars_to_hex(hi, lo))
+    }
+}
+
+impl<'a> ExactSizeIterator for HexToBytesIter<'a> {}
+
+impl<'a> core::iter::FusedIterator for HexToBytesIter<'a> {}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -14,8 +14,13 @@ use crate::parse::HexToBytesError;
 
 /// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
 pub struct HexToBytesIter<'a> {
-    /// The `Bytes` iterator whose next two bytes will be decoded to yield
-    /// the next byte.
+    /// The [`Bytes`] iterator whose next two bytes will be decoded to yield the next byte.
+    ///
+    /// # Invariants
+    ///
+    /// `iter` is guaranteed to be of even length.
+    ///
+    /// [`Bytes`]: core::str::Bytes
     iter: str::Bytes<'a>,
 }
 
@@ -39,7 +44,7 @@ impl<'a> Iterator for HexToBytesIter<'a> {
 
     fn next(&mut self) -> Option<Result<u8, HexToBytesError>> {
         let hi = self.iter.next()?;
-        let lo = self.iter.next().unwrap();
+        let lo = self.iter.next().expect("iter length invariant violated, this is a bug");
         Some(hex_chars_to_byte(hi, lo))
     }
 
@@ -52,12 +57,14 @@ impl<'a> Iterator for HexToBytesIter<'a> {
 impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
     fn next_back(&mut self) -> Option<Result<u8, HexToBytesError>> {
         let lo = self.iter.next_back()?;
-        let hi = self.iter.next_back().unwrap();
+        let hi = self.iter.next_back().expect("iter length invariant violated, this is a bug");
         Some(hex_chars_to_byte(hi, lo))
     }
 }
 
-impl<'a> ExactSizeIterator for HexToBytesIter<'a> {}
+impl<'a> ExactSizeIterator for HexToBytesIter<'a> {
+    fn len(&self) -> usize { self.iter.len() / 2 }
+}
 
 impl<'a> core::iter::FusedIterator for HexToBytesIter<'a> {}
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -2,6 +2,7 @@
 
 //! Iterator that converts hex to bytes.
 
+use core::iter::FusedIterator;
 use core::str;
 #[cfg(feature = "std")]
 use std::io;
@@ -84,4 +85,159 @@ fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
 
     let ret = (hih << 4) + loh;
     Ok(ret as u8)
+}
+
+/// Iterator over bytes which encodes the bytes and yields hex characters.
+pub struct BytesToHexIter<I: ExactSizeIterator + FusedIterator + Iterator<Item = u8>> {
+    /// The iterator whose next byte will be encoded to yield hex characters.
+    iter: I,
+    /// The low character of the pair (high, low) of hex characters encoded per byte.
+    low: Option<char>,
+}
+
+impl<I> BytesToHexIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = u8>,
+{
+    /// Constructs a new `BytesToHexIter` from a byte iterator.
+    pub fn new(iter: I) -> BytesToHexIter<I> { Self { iter, low: None } }
+}
+
+impl<I> Iterator for BytesToHexIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = u8>,
+{
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        match self.low {
+            Some(c) => {
+                self.low = None;
+                Some(c)
+            }
+            None => self.iter.next().map(|b| {
+                let (high, low) = byte_to_hex_chars(b);
+                self.low = Some(low);
+                high
+            }),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (self.len(), Some(self.len())) }
+}
+
+impl<I> DoubleEndedIterator for BytesToHexIter<I>
+where
+    I: DoubleEndedIterator + ExactSizeIterator + FusedIterator + Iterator<Item = u8>,
+{
+    fn next_back(&mut self) -> Option<char> {
+        match self.low {
+            Some(c) => {
+                self.low = None;
+                Some(c)
+            }
+            None => self.iter.next_back().map(|b| {
+                let (high, low) = byte_to_hex_chars(b);
+                self.low = Some(low);
+                high
+            }),
+        }
+    }
+}
+
+impl<I> ExactSizeIterator for BytesToHexIter<I>
+where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = u8>,
+{
+    fn len(&self) -> usize { self.iter.len() * 2 + self.low.map_or(0, |_| 1) }
+}
+
+impl<I> FusedIterator for BytesToHexIter<I> where
+    I: ExactSizeIterator + FusedIterator + Iterator<Item = u8>
+{
+}
+
+/// Returns the (high, low) hex characters encoding `b`.
+fn byte_to_hex_chars(b: u8) -> (char, char) {
+    const HEX_TABLE: [u8; 16] = *b"0123456789abcdef";
+
+    let high = HEX_TABLE[usize::from(b >> 4)];
+    let low = HEX_TABLE[usize::from(b & 0b00001111)];
+
+    (char::from(high), char::from(low))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_byte() {
+        let tcs =
+            vec![(0x00, ('0', '0')), (0x0a, ('0', 'a')), (0xad, ('a', 'd')), (0xff, ('f', 'f'))];
+        for (b, (high, low)) in tcs {
+            assert_eq!(byte_to_hex_chars(b), (high, low));
+        }
+        assert_eq!(byte_to_hex_chars(0x00), ('0', '0'));
+        assert_eq!(byte_to_hex_chars(0x0a), ('0', 'a'));
+        assert_eq!(byte_to_hex_chars(0xad), ('a', 'd'));
+        assert_eq!(byte_to_hex_chars(0xff), ('f', 'f'));
+    }
+
+    #[test]
+    fn decode_iter_forward() {
+        let hex = "deadbeef";
+        let v = vec![0xde, 0xad, 0xbe, 0xef];
+
+        for (i, b) in HexToBytesIter::new(hex).unwrap().enumerate() {
+            assert_eq!(b.unwrap(), v[i]);
+        }
+    }
+
+    #[test]
+    fn decode_iter_backward() {
+        let hex = "deadbeef";
+        // TODO: Confirm that this is what we want, the digits are still ordered (high, low)?
+        let v = vec![0xef, 0xbe, 0xad, 0xde];
+
+        for (i, b) in HexToBytesIter::new(hex).unwrap().rev().enumerate() {
+            assert_eq!(b.unwrap(), v[i]);
+        }
+    }
+
+    #[test]
+    fn encode_iter() {
+        let v = vec![0xde, 0xad, 0xbe, 0xef];
+        let hex = "deadbeef";
+
+        for (i, c) in BytesToHexIter::new(v.iter().cloned()).enumerate() {
+            assert_eq!(c, hex.chars().nth(i).unwrap());
+        }
+    }
+
+    #[test]
+    fn encode_iter_backwards() {
+        let v = vec![0xde, 0xad, 0xbe, 0xef];
+        let hex = "efbeadde";
+
+        for (i, c) in BytesToHexIter::new(v.iter().cloned()).rev().enumerate() {
+            assert_eq!(c, hex.chars().nth(i).unwrap());
+        }
+    }
+
+    #[test]
+    fn roundtrip_forward() {
+        let hex = "deadbeefcafebabe";
+        let bytes_iter = HexToBytesIter::new(hex).unwrap().map(|res| res.unwrap());
+        let got = BytesToHexIter::new(bytes_iter).collect::<String>();
+        assert_eq!(got, hex);
+    }
+
+    #[test]
+    fn roundtrip_backward() {
+        let hex = "deadbeefcafebabe";
+        let bytes_iter = HexToBytesIter::new(hex).unwrap().rev().map(|res| res.unwrap());
+        let got = BytesToHexIter::new(bytes_iter).rev().collect::<String>();
+        assert_eq!(got, hex);
+    }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -33,14 +33,6 @@ impl<'a> HexToBytesIter<'a> {
     }
 }
 
-fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
-    let hih = (hi as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(hi))?;
-    let loh = (lo as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(lo))?;
-
-    let ret = (hih << 4) + loh;
-    Ok(ret as u8)
-}
-
 impl<'a> Iterator for HexToBytesIter<'a> {
     type Item = Result<u8, HexToBytesError>;
 
@@ -55,6 +47,18 @@ impl<'a> Iterator for HexToBytesIter<'a> {
         (min / 2, max.map(|x| x / 2))
     }
 }
+
+impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
+    fn next_back(&mut self) -> Option<Result<u8, HexToBytesError>> {
+        let lo = self.iter.next_back()?;
+        let hi = self.iter.next_back().unwrap();
+        Some(chars_to_hex(hi, lo))
+    }
+}
+
+impl<'a> ExactSizeIterator for HexToBytesIter<'a> {}
+
+impl<'a> core::iter::FusedIterator for HexToBytesIter<'a> {}
 
 #[cfg(any(feature = "std", feature = "core2"))]
 impl<'a> io::Read for HexToBytesIter<'a> {
@@ -73,14 +77,10 @@ impl<'a> io::Read for HexToBytesIter<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
-    fn next_back(&mut self) -> Option<Result<u8, HexToBytesError>> {
-        let lo = self.iter.next_back()?;
-        let hi = self.iter.next_back().unwrap();
-        Some(chars_to_hex(hi, lo))
-    }
+fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
+    let hih = (hi as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(hi))?;
+    let loh = (lo as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(lo))?;
+
+    let ret = (hih << 4) + loh;
+    Ok(ret as u8)
 }
-
-impl<'a> ExactSizeIterator for HexToBytesIter<'a> {}
-
-impl<'a> core::iter::FusedIterator for HexToBytesIter<'a> {}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -39,7 +39,7 @@ impl<'a> Iterator for HexToBytesIter<'a> {
     fn next(&mut self) -> Option<Result<u8, HexToBytesError>> {
         let hi = self.iter.next()?;
         let lo = self.iter.next().unwrap();
-        Some(chars_to_hex(hi, lo))
+        Some(hex_chars_to_byte(hi, lo))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -52,7 +52,7 @@ impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
     fn next_back(&mut self) -> Option<Result<u8, HexToBytesError>> {
         let lo = self.iter.next_back()?;
         let hi = self.iter.next_back().unwrap();
-        Some(chars_to_hex(hi, lo))
+        Some(hex_chars_to_byte(hi, lo))
     }
 }
 
@@ -77,7 +77,8 @@ impl<'a> io::Read for HexToBytesIter<'a> {
     }
 }
 
-fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
+/// `hi` and `lo` are bytes representing hex characters.
+fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
     let hih = (hi as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(hi))?;
     let loh = (lo as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(lo))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub mod display;
 pub mod parse;
 
 pub use display::DisplayHex;
-pub use parse::{Error, FromHex, Iter};
+pub use parse::{Error, FromHex, HexToBytesIter};
 
 /// Reexports of extension traits.
 pub mod exts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,12 @@ extern crate alloc;
 pub mod buf_encoder;
 pub mod display;
 mod error;
+mod iter;
 pub mod parse;
 
 pub use display::DisplayHex;
-pub use parse::{FromHex, HexToArrayError, HexToBytesError, HexToBytesIter};
+pub use iter::HexToBytesIter;
+pub use parse::{FromHex, HexToArrayError, HexToBytesError};
 
 /// Reexports of extension traits.
 pub mod exts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ mod iter;
 pub mod parse;
 
 pub use display::DisplayHex;
-pub use iter::HexToBytesIter;
+pub use iter::{BytesToHexIter, HexToBytesIter};
 pub use parse::{FromHex, HexToArrayError, HexToBytesError};
 
 /// Reexports of extension traits.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,11 @@ extern crate alloc;
 
 pub mod buf_encoder;
 pub mod display;
+mod error;
 pub mod parse;
 
 pub use display::DisplayHex;
-pub use parse::{Error, FromHex, HexToBytesIter};
+pub use parse::{FromHex, HexToArrayError, HexToBytesError, HexToBytesIter};
 
 /// Reexports of extension traits.
 pub mod exts {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -14,13 +14,18 @@ use crate::alloc::vec::Vec;
 
 /// Trait for objects that can be deserialized from hex strings.
 pub trait FromHex: Sized {
+    /// Error type returned while parsing hex string.
+    type Error: From<HexToBytesError> + Sized + fmt::Debug + fmt::Display;
+
     /// Produces an object from a byte iterator.
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
     where
-        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator;
+        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator;
 
     /// Produces an object from a hex string.
-    fn from_hex(s: &str) -> Result<Self, Error> { Self::from_byte_iter(HexToBytesIter::new(s)?) }
+    fn from_hex(s: &str) -> Result<Self, Self::Error> {
+        Self::from_byte_iter(HexToBytesIter::new(s)?)
+    }
 }
 
 /// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
@@ -36,27 +41,27 @@ impl<'a> HexToBytesIter<'a> {
     /// # Errors
     ///
     /// If the input string is of odd length.
-    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, Error> {
+    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, HexToBytesError> {
         if s.len() % 2 != 0 {
-            Err(Error::OddLengthString(s.len()))
+            Err(HexToBytesError::OddLengthString(s.len()))
         } else {
             Ok(HexToBytesIter { iter: s.bytes() })
         }
     }
 }
 
-fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, Error> {
-    let hih = (hi as char).to_digit(16).ok_or(Error::InvalidChar(hi))?;
-    let loh = (lo as char).to_digit(16).ok_or(Error::InvalidChar(lo))?;
+fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
+    let hih = (hi as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(hi))?;
+    let loh = (lo as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(lo))?;
 
     let ret = (hih << 4) + loh;
     Ok(ret as u8)
 }
 
 impl<'a> Iterator for HexToBytesIter<'a> {
-    type Item = Result<u8, Error>;
+    type Item = Result<u8, HexToBytesError>;
 
-    fn next(&mut self) -> Option<Result<u8, Error>> {
+    fn next(&mut self) -> Option<Result<u8, HexToBytesError>> {
         let hi = self.iter.next()?;
         let lo = self.iter.next().unwrap();
         Some(chars_to_hex(hi, lo))
@@ -86,7 +91,7 @@ impl<'a> io::Read for HexToBytesIter<'a> {
 }
 
 impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
-    fn next_back(&mut self) -> Option<Result<u8, Error>> {
+    fn next_back(&mut self) -> Option<Result<u8, HexToBytesError>> {
         let lo = self.iter.next_back()?;
         let hi = self.iter.next_back().unwrap();
         Some(chars_to_hex(hi, lo))
@@ -99,20 +104,57 @@ impl<'a> core::iter::FusedIterator for HexToBytesIter<'a> {}
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
 impl FromHex for Vec<u8> {
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+    type Error = HexToBytesError;
+
+    fn from_byte_iter<I>(iter: I) -> Result<Self, HexToBytesError>
     where
-        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         iter.collect()
+    }
+}
+
+/// Hex decoding error.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum HexToBytesError {
+    /// Non-hexadecimal character.
+    InvalidChar(u8),
+    /// Purported hex string had odd length.
+    OddLengthString(usize),
+}
+
+impl fmt::Display for HexToBytesError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::HexToBytesError::*;
+
+        match *self {
+            InvalidChar(ch) => write!(f, "invalid hex character {}", ch),
+            OddLengthString(ell) => write!(f, "odd hex string length {}", ell),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HexToBytesError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::HexToBytesError::*;
+
+        match self {
+            InvalidChar(_) | OddLengthString(_) => None,
+        }
     }
 }
 
 macro_rules! impl_fromhex_array {
     ($len:expr) => {
         impl FromHex for [u8; $len] {
-            fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+            type Error = HexToArrayError;
+
+            fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
             where
-                I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
+                I: Iterator<Item = Result<u8, HexToBytesError>>
+                    + ExactSizeIterator
+                    + DoubleEndedIterator,
             {
                 if iter.len() == $len {
                     let mut ret = [0; $len];
@@ -121,7 +163,7 @@ macro_rules! impl_fromhex_array {
                     }
                     Ok(ret)
                 } else {
-                    Err(Error::InvalidLength(2 * $len, 2 * iter.len()))
+                    Err(HexToArrayError::InvalidLength(2 * $len, 2 * iter.len()))
                 }
             }
         }
@@ -150,77 +192,76 @@ impl_fromhex_array!(512);
 
 /// Hex decoding error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Error {
-    /// Non-hexadecimal character.
-    InvalidChar(u8),
-    /// Purported hex string had odd length.
-    OddLengthString(usize),
-    /// Tried to parse fixed-length hash from a string with the wrong type (expected, got).
+pub enum HexToArrayError {
+    /// Conversion error while parsing hex string.
+    Conversion(HexToBytesError),
+    /// Tried to parse fixed-length hash from a string with the wrong length (got, want).
     InvalidLength(usize, usize),
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for HexToArrayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use HexToArrayError::*;
+
         match *self {
-            Error::InvalidChar(ch) => write!(f, "invalid hex character {}", ch),
-            Error::OddLengthString(ell) => write!(f, "odd hex string length {}", ell),
-            Error::InvalidLength(ell, ell2) =>
-                write!(f, "bad hex string length {} (expected {})", ell2, ell),
+            Conversion(ref e) => crate::write_err!(f, "conversion error"; e),
+            InvalidLength(got, want) =>
+                write!(f, "bad hex string length {} (expected {})", got, want),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
+impl std::error::Error for HexToArrayError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use self::Error::*;
+        use HexToArrayError::*;
 
-        match self {
-            InvalidChar(_) | OddLengthString(_) | InvalidLength(_, _) => None,
+        match *self {
+            Conversion(ref e) => Some(e),
+            InvalidLength(_, _) => None,
         }
     }
 }
 
+impl From<HexToBytesError> for HexToArrayError {
+    fn from(e: HexToBytesError) -> Self { Self::Conversion(e) }
+}
+
 #[cfg(test)]
-#[cfg(feature = "alloc")]
 mod tests {
     use super::*;
     use crate::display::DisplayHex;
 
     #[test]
-    fn hex_roundtrip() {
-        let expected = "0123456789abcdef";
-        let expected_up = "0123456789ABCDEF";
-
-        let parse: Vec<u8> = FromHex::from_hex(expected).expect("parse lowercase string");
-        assert_eq!(parse, vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
-        let ser = parse.to_lower_hex_string();
-        assert_eq!(ser, expected);
-
-        let parse: Vec<u8> = FromHex::from_hex(expected_up).expect("parse uppercase string");
-        assert_eq!(parse, vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
-        let ser = parse.to_lower_hex_string();
-        assert_eq!(ser, expected);
-
-        let parse: [u8; 8] = FromHex::from_hex(expected_up).expect("parse uppercase string");
-        assert_eq!(parse, [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
-        let ser = parse.to_lower_hex_string();
-        assert_eq!(ser, expected);
-    }
-
-    #[test]
+    #[cfg(feature = "alloc")]
     fn hex_error() {
+        use HexToBytesError::*;
+
         let oddlen = "0123456789abcdef0";
         let badchar1 = "Z123456789abcdef";
         let badchar2 = "012Y456789abcdeb";
         let badchar3 = "«23456789abcdef";
 
-        assert_eq!(Vec::<u8>::from_hex(oddlen), Err(Error::OddLengthString(17)));
-        assert_eq!(<[u8; 4]>::from_hex(oddlen), Err(Error::OddLengthString(17)));
-        assert_eq!(<[u8; 8]>::from_hex(oddlen), Err(Error::OddLengthString(17)));
-        assert_eq!(Vec::<u8>::from_hex(badchar1), Err(Error::InvalidChar(b'Z')));
-        assert_eq!(Vec::<u8>::from_hex(badchar2), Err(Error::InvalidChar(b'Y')));
-        assert_eq!(Vec::<u8>::from_hex(badchar3), Err(Error::InvalidChar(194)));
+        assert_eq!(Vec::<u8>::from_hex(oddlen), Err(OddLengthString(17)));
+        assert_eq!(
+            <[u8; 4]>::from_hex(oddlen),
+            Err(HexToArrayError::Conversion(OddLengthString(17)))
+        );
+        assert_eq!(Vec::<u8>::from_hex(badchar1), Err(InvalidChar(b'Z')));
+        assert_eq!(Vec::<u8>::from_hex(badchar2), Err(InvalidChar(b'Y')));
+        assert_eq!(Vec::<u8>::from_hex(badchar3), Err(InvalidChar(194)));
+    }
+
+    #[test]
+    fn hex_to_array() {
+        let len_sixteen = "0123456789abcdef";
+        assert!(<[u8; 8]>::from_hex(len_sixteen).is_ok());
+    }
+    #[test]
+    fn hex_to_array_error() {
+        use HexToArrayError::*;
+        let len_sixteen = "0123456789abcdef";
+        assert_eq!(<[u8; 4]>::from_hex(len_sixteen), Err(InvalidLength(8, 16)));
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -20,27 +20,27 @@ pub trait FromHex: Sized {
         I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator;
 
     /// Produces an object from a hex string.
-    fn from_hex(s: &str) -> Result<Self, Error> { Self::from_byte_iter(Iter::new(s)?) }
+    fn from_hex(s: &str) -> Result<Self, Error> { Self::from_byte_iter(HexToBytesIter::new(s)?) }
 }
 
 /// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
-pub struct Iter<'a> {
+pub struct HexToBytesIter<'a> {
     /// The `Bytes` iterator whose next two bytes will be decoded to yield
     /// the next byte.
     iter: str::Bytes<'a>,
 }
 
-impl<'a> Iter<'a> {
-    /// Constructs a new `Iter` from a string slice.
+impl<'a> HexToBytesIter<'a> {
+    /// Constructs a new `HexToBytesIter` from a string slice.
     ///
     /// # Errors
     ///
     /// If the input string is of odd length.
-    pub fn new(s: &'a str) -> Result<Iter<'a>, Error> {
+    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, Error> {
         if s.len() % 2 != 0 {
             Err(Error::OddLengthString(s.len()))
         } else {
-            Ok(Iter { iter: s.bytes() })
+            Ok(HexToBytesIter { iter: s.bytes() })
         }
     }
 }
@@ -53,7 +53,7 @@ fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, Error> {
     Ok(ret as u8)
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl<'a> Iterator for HexToBytesIter<'a> {
     type Item = Result<u8, Error>;
 
     fn next(&mut self) -> Option<Result<u8, Error>> {
@@ -69,7 +69,7 @@ impl<'a> Iterator for Iter<'a> {
 }
 
 #[cfg(any(feature = "std", feature = "core2"))]
-impl<'a> io::Read for Iter<'a> {
+impl<'a> io::Read for HexToBytesIter<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut bytes_read = 0usize;
         for dst in buf {
@@ -85,7 +85,7 @@ impl<'a> io::Read for Iter<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Iter<'a> {
+impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
     fn next_back(&mut self) -> Option<Result<u8, Error>> {
         let lo = self.iter.next_back()?;
         let hi = self.iter.next_back().unwrap();
@@ -93,7 +93,7 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for Iter<'a> {}
+impl<'a> ExactSizeIterator for HexToBytesIter<'a> {}
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
 impl FromHex for Vec<u8> {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,14 +3,10 @@
 //! Hex encoding and decoding.
 
 use core::{fmt, str};
-#[cfg(feature = "std")]
-use std::io;
-
-#[cfg(all(feature = "core2", not(feature = "std")))]
-use core2::io;
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use crate::alloc::vec::Vec;
+use crate::iter::HexToBytesIter;
 
 /// Trait for objects that can be deserialized from hex strings.
 pub trait FromHex: Sized {
@@ -27,80 +23,6 @@ pub trait FromHex: Sized {
         Self::from_byte_iter(HexToBytesIter::new(s)?)
     }
 }
-
-/// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
-pub struct HexToBytesIter<'a> {
-    /// The `Bytes` iterator whose next two bytes will be decoded to yield
-    /// the next byte.
-    iter: str::Bytes<'a>,
-}
-
-impl<'a> HexToBytesIter<'a> {
-    /// Constructs a new `HexToBytesIter` from a string slice.
-    ///
-    /// # Errors
-    ///
-    /// If the input string is of odd length.
-    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, HexToBytesError> {
-        if s.len() % 2 != 0 {
-            Err(HexToBytesError::OddLengthString(s.len()))
-        } else {
-            Ok(HexToBytesIter { iter: s.bytes() })
-        }
-    }
-}
-
-fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
-    let hih = (hi as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(hi))?;
-    let loh = (lo as char).to_digit(16).ok_or(HexToBytesError::InvalidChar(lo))?;
-
-    let ret = (hih << 4) + loh;
-    Ok(ret as u8)
-}
-
-impl<'a> Iterator for HexToBytesIter<'a> {
-    type Item = Result<u8, HexToBytesError>;
-
-    fn next(&mut self) -> Option<Result<u8, HexToBytesError>> {
-        let hi = self.iter.next()?;
-        let lo = self.iter.next().unwrap();
-        Some(chars_to_hex(hi, lo))
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let (min, max) = self.iter.size_hint();
-        (min / 2, max.map(|x| x / 2))
-    }
-}
-
-#[cfg(any(feature = "std", feature = "core2"))]
-impl<'a> io::Read for HexToBytesIter<'a> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut bytes_read = 0usize;
-        for dst in buf {
-            match self.next() {
-                Some(Ok(src)) => {
-                    *dst = src;
-                    bytes_read += 1;
-                }
-                _ => break,
-            }
-        }
-        Ok(bytes_read)
-    }
-}
-
-impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
-    fn next_back(&mut self) -> Option<Result<u8, HexToBytesError>> {
-        let lo = self.iter.next_back()?;
-        let hi = self.iter.next_back().unwrap();
-        Some(chars_to_hex(hi, lo))
-    }
-}
-
-impl<'a> ExactSizeIterator for HexToBytesIter<'a> {}
-
-impl<'a> core::iter::FusedIterator for HexToBytesIter<'a> {}
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
 impl FromHex for Vec<u8> {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -95,6 +95,8 @@ impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
 
 impl<'a> ExactSizeIterator for HexToBytesIter<'a> {}
 
+impl<'a> core::iter::FusedIterator for HexToBytesIter<'a> {}
+
 #[cfg(any(test, feature = "std", feature = "alloc"))]
 impl FromHex for Vec<u8> {
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>


### PR DESCRIPTION
@Kixunil is back now, this can be draft until #9 goes in.

The `HexToBytesIter` maintains an invariant that its inner char iterator is of even length. Make this explicit.

