### PR TITLE
Add changelog and prep for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 0.1.0 - 2023-06-20 Initial Release
+
+- [Import](https://github.com/rust-bitcoin/hex-conservative/pull/1) code from the `bitcoin_hashes` and `bitcoin-internals` crates.
+- [Add `Iterator` implementations](https://github.com/rust-bitcoin/hex-conservative/pull/9)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.0.1" }
+hex = { path = "..", package = "hex-conservative", version = "0.1.0" }
 
 [[bin]]
 name = "hex"

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -21,7 +21,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.0.1" }
+hex = { path = "..", package = "hex-conservative", version = "0.1.0" }
 EOF
 
 for targetFile in $(listTargetFiles); do

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -207,7 +207,6 @@ mod tests {
     #[test]
     fn decode_iter_backward() {
         let hex = "deadbeef";
-        // TODO: Confirm that this is what we want, the digits are still ordered (high, low)?
         let v = vec![0xef, 0xbe, 0xad, 0xde];
 
         for (i, b) in HexToBytesIter::new(hex).unwrap().rev().enumerate() {


### PR DESCRIPTION
Prepare for release by doing:

- Bump the version to 0.1.0
- Add changelog file and populate an entry for v0.1.0

Now includes initial patch to remove the todo (see suggested in discussion below). FTR I introduced the todo in #9.

## Merge before release

- #20 
- #21
