### PR TITLE
Implement suggestions after crate usage in rust-elements

### DIFF
--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -60,9 +60,9 @@ impl fmt::UpperHex for Hexy {
 // And use a fixed size array to convert from hex.
 
 impl FromHex for Hexy {
-    type Error = HexToArrayError;
+    type Err = HexToArrayError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Err>
     where
         I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
     {

--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -16,6 +16,7 @@ fn main() {
 }
 
 /// A struct that always uses hex when in string form.
+#[derive(Debug)] // Manually implement Debug as we do for display below if you want the output in hex.
 pub struct Hexy {
     // Some opaque data.
     data: [u8; 32],

--- a/fuzz/fuzz_targets/hex.rs
+++ b/fuzz/fuzz_targets/hex.rs
@@ -40,7 +40,7 @@ impl fmt::UpperHex for Hexy {
 }
 
 impl FromHex for Hexy {
-    type Error = HexToArrayError;
+    type Err = HexToArrayError;
 
     fn from_byte_iter<I>(iter: I) -> Result<Self, HexToArrayError>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! let v = Vec::from_hex("deadbeef").expect("valid hex digits");
 //! // Or a known length hex string into a fixed size array.
 //! let a = <[u8; 4]>::from_hex("deadbeef").expect("valid length and valid hex digits");
-//! // We support `LowerHex` and `UpperHex` out of the box for `[u8]` slices.
+//! // We support `LowerHex` and `UpperHex` out of the box for `[u8]` arrays and slices.
 //! println!("An array as lower hex: {:x}", a.as_hex());
 //! // And for vecs since `Vec` derefs to byte slice.
 //! println!("A vector as upper hex: {:X}", v.as_hex());

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -11,22 +11,22 @@ use crate::iter::HexToBytesIter;
 /// Trait for objects that can be deserialized from hex strings.
 pub trait FromHex: Sized {
     /// Error type returned while parsing hex string.
-    type Error: From<HexToBytesError> + Sized + fmt::Debug + fmt::Display;
+    type Err: From<HexToBytesError> + Sized + fmt::Debug + fmt::Display;
 
     /// Produces an object from a byte iterator.
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Err>
     where
         I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator;
 
     /// Produces an object from a hex string.
-    fn from_hex(s: &str) -> Result<Self, Self::Error> {
+    fn from_hex(s: &str) -> Result<Self, Self::Err> {
         Self::from_byte_iter(HexToBytesIter::new(s)?)
     }
 }
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
 impl FromHex for Vec<u8> {
-    type Error = HexToBytesError;
+    type Err = HexToBytesError;
 
     fn from_byte_iter<I>(iter: I) -> Result<Self, HexToBytesError>
     where
@@ -70,9 +70,9 @@ impl std::error::Error for HexToBytesError {
 macro_rules! impl_fromhex_array {
     ($len:expr) => {
         impl FromHex for [u8; $len] {
-            type Error = HexToArrayError;
+            type Err = HexToArrayError;
 
-            fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+            fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Err>
             where
                 I: Iterator<Item = Result<u8, HexToBytesError>>
                     + ExactSizeIterator


### PR DESCRIPTION
Recently @apoelstra attempted to use this crate in `rust-elemements`, a few things came out in the wash (https://github.com/rust-bitcoin/hex-conservative/pull/15#issuecomment-1613578223)

Created #17 for the error rename.

This PR is a mess, changing to draft just to keep the discussion.
