### PR TITLE
Use Err for the associated error type of FromHex

### DIFF
--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -60,9 +60,9 @@ impl fmt::UpperHex for Hexy {
 // And use a fixed size array to convert from hex.
 
 impl FromHex for Hexy {
-    type Error = HexToArrayError;
+    type Err = HexToArrayError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Err>
     where
         I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
     {

--- a/fuzz/fuzz_targets/hex.rs
+++ b/fuzz/fuzz_targets/hex.rs
@@ -40,7 +40,7 @@ impl fmt::UpperHex for Hexy {
 }
 
 impl FromHex for Hexy {
-    type Error = HexToArrayError;
+    type Err = HexToArrayError;
 
     fn from_byte_iter<I>(iter: I) -> Result<Self, HexToArrayError>
     where

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -11,24 +11,24 @@ use crate::iter::HexToBytesIter;
 /// Trait for objects that can be deserialized from hex strings.
 pub trait FromHex: Sized {
     /// Error type returned while parsing hex string.
-    type Error: From<HexToBytesError> + Sized + fmt::Debug + fmt::Display;
+    type Err: From<HexToBytesError> + Sized + fmt::Debug + fmt::Display;
 
     /// Produces an object from a byte iterator.
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Err>
     where
         I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator;
 
     /// Produces an object from a hex string.
-    fn from_hex(s: &str) -> Result<Self, Self::Error> {
+    fn from_hex(s: &str) -> Result<Self, Self::Err> {
         Self::from_byte_iter(HexToBytesIter::new(s)?)
     }
 }
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
 impl FromHex for Vec<u8> {
-    type Error = HexToBytesError;
+    type Err = HexToBytesError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, HexToBytesError>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Err>
     where
         I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
     {
@@ -70,9 +70,9 @@ impl std::error::Error for HexToBytesError {
 macro_rules! impl_fromhex_array {
     ($len:expr) => {
         impl FromHex for [u8; $len] {
-            type Error = HexToArrayError;
+            type Err = HexToArrayError;
 
-            fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+            fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Err>
             where
                 I: Iterator<Item = Result<u8, HexToBytesError>>
                     + ExactSizeIterator


### PR DESCRIPTION
The `FromHex` trait parses a hex string, as such it is quite like `FromStr` - it makes sense for the associated error to be named the same `Err` instead of `Error` (is it is in `TryFrom` and other places).