### PR TITLE
Add trait bounds Debug and Display to DisplayHex::Display

### DIFF
--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -5,7 +5,9 @@
 use std::fmt;
 use std::str::FromStr;
 
-use hex_conservative::{fmt_hex_exact, Case, FromHex, HexToArrayError, HexToBytesError};
+use hex_conservative::{
+    fmt_hex_exact, Case, DisplayHex, FromHex, HexToArrayError, HexToBytesError,
+};
 
 fn main() {
     let s = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
@@ -24,6 +26,12 @@ pub struct Hexy {
 impl Hexy {
     /// Demonstrates getting internal opaque data as a byte slice.
     pub fn as_bytes(&self) -> &[u8] { &self.data }
+}
+
+impl fmt::Debug for Hexy {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        fmt::Formatter::debug_struct(f, "Hexy").field("data", &self.data.as_hex()).finish()
+    }
 }
 
 // Note we implement `Display` and `FromStr` using `LowerHex`/`FromHex` respectively, if this was a

--- a/src/display.rs
+++ b/src/display.rs
@@ -25,7 +25,7 @@ pub trait DisplayHex: Copy + sealed::IsRef {
     /// The type providing [`fmt::Display`] implementation.
     ///
     /// This is usually a wrapper type holding a reference to `Self`.
-    type Display: fmt::LowerHex + fmt::UpperHex;
+    type Display: fmt::Display + fmt::Debug + fmt::LowerHex + fmt::UpperHex;
 
     /// Display `Self` as a continuous sequence of ASCII hex chars.
     fn as_hex(self) -> Self::Display;
@@ -148,6 +148,14 @@ impl<'a> DisplayByteSlice<'a> {
     }
 }
 
+impl<'a> fmt::Display for DisplayByteSlice<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
+}
+
+impl<'a> fmt::Debug for DisplayByteSlice<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
+}
+
 impl<'a> fmt::LowerHex for DisplayByteSlice<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Lower) }
 }
@@ -180,6 +188,20 @@ where
         encoder.put_bytes(self.array.clone(), case);
         f.pad_integral(true, "0x", encoder.as_str())
     }
+}
+
+impl<A: Clone + IntoIterator, B: FixedLenBuf> fmt::Display for DisplayArray<A, B>
+where
+    A::Item: Borrow<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
+}
+
+impl<A: Clone + IntoIterator, B: FixedLenBuf> fmt::Debug for DisplayArray<A, B>
+where
+    A::Item: Borrow<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
 }
 
 impl<A: Clone + IntoIterator, B: FixedLenBuf> fmt::LowerHex for DisplayArray<A, B>


### PR DESCRIPTION
Add trait bounds `Debug` and `Display` to the `DisplayHex::Display` associated type and add implementations for `DisplayByteSlice` and `DisplayArray`.