### PR TITLE
Add more documentation to the fmt_hex_exact macro

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -226,6 +226,10 @@ where
 /// not requested. This is designed to display values such as hashes and keys and removing leading
 /// zeros would be confusing.
 ///
+/// Note that the bytes parameter is `IntoIterator` this means that if you would like to do some
+/// manipulation to the byte array before formatting then you can. For example `bytes.iter().rev()`
+/// to print the array backwards.
+///
 /// ## Parameters
 ///
 /// * `$formatter` - a [`fmt::Formatter`].


### PR DESCRIPTION
The `fmt_hex_exact` macro takes bytes as `IntoIterator`, this makes it quite flexible. Add more documentation to the macro, giving an example of formatting an array in reverse.