### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.1 - 2023-07-19
+
+- [Add `test_hex_unwrap`](https://github.com/rust-bitcoin/hex-conservative/pull/24) hex parsing macro for test usage.
+- [Improve formatting](https://github.com/rust-bitcoin/hex-conservative/pull/25) hex for bytes slices e.g., support padding.
+
 # 0.1.0 - 2023-06-20 Initial Release
 
 - [Import](https://github.com/rust-bitcoin/hex-conservative/pull/1) code from the `bitcoin_hashes` and `bitcoin-internals` crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.1.0" }
+hex = { path = "..", package = "hex-conservative", version = "0.1.1" }
 
 [[bin]]
 name = "hex"

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -21,7 +21,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.1.0" }
+hex = { path = "..", package = "hex-conservative", version = "0.2.0" }
 EOF
 
 for targetFile in $(listTargetFiles); do


### PR DESCRIPTION
- Patch 1 is #25, required for this release.
- Patch 2 bumps the version and adds changelog.