### PR TITLE
Rename the library to hex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 edition = "2018"
 exclude = ["tests", "contrib"]
 
+[lib]
+name = "hex"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -6,7 +6,7 @@
 use core::fmt;
 use core::str::FromStr;
 
-use hex_conservative::{DisplayHex, FromHex, HexToArrayError, HexToBytesError};
+use hex::{DisplayHex, FromHex, HexToArrayError, HexToBytesError};
 
 fn main() {
     let s = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";

--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -6,9 +6,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use hex_conservative::{
-    fmt_hex_exact, Case, DisplayHex, FromHex, HexToArrayError, HexToBytesError,
-};
+use hex::{fmt_hex_exact, Case, DisplayHex, FromHex, HexToArrayError, HexToBytesError};
 
 fn main() {
     let s = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";

--- a/examples/wrap_array_display_hex_trait.rs
+++ b/examples/wrap_array_display_hex_trait.rs
@@ -4,8 +4,8 @@
 //!
 //! For an example using the standard library `fmt` traits see `./wrap_array_fmt_traits.rs`.
 
-use hex_conservative::display::DisplayArray;
-use hex_conservative::{DisplayHex, FromHex, HexToArrayError, HexToBytesError};
+use hex::display::DisplayArray;
+use hex::{DisplayHex, FromHex, HexToArrayError, HexToBytesError};
 
 fn main() {
     let hex = "00000000cafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";

--- a/examples/wrap_array_fmt_traits.rs
+++ b/examples/wrap_array_fmt_traits.rs
@@ -7,7 +7,7 @@
 use core::fmt;
 use core::str::FromStr;
 
-use hex_conservative::{DisplayHex, FromHex, HexToArrayError};
+use hex::{DisplayHex, FromHex, HexToArrayError};
 
 fn main() {
     let hex = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.1.1" }
+hex-conservative = { path = "../", version = "0.1.1" }
 
 [[bin]]
 name = "hex"

--- a/src/display.rs
+++ b/src/display.rs
@@ -10,7 +10,7 @@
 //! # Examples
 //!
 //! ```
-//! use hex_conservative::DisplayHex;
+//! use hex::DisplayHex;
 //!
 //! // Display as hex.
 //! let v = vec![0xde, 0xad, 0xbe, 0xef];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,6 @@
 //! ## Basic Usage
 //! ```
 //! # #[cfg(feature = "alloc")] {
-//! // Use the `package` key to improve import ergonomics (`hex` instead of `hex-conservative`).
-//! // hex = { package = "hex-conservative", version = "*" }
-//! # use hex_conservative as hex; // No need for this if using `package` as above.
 //! use hex::{DisplayHex, FromHex};
 //!
 //! // Decode an arbitrary length hex string into a vector.
@@ -108,7 +105,7 @@ pub(crate) fn byte_to_hex(byte: u8, table: &[u8; 16]) -> [u8; 2] {
 
 /// Quick and dirty macro for parsing hex in tests.
 ///
-/// For improved ergonomics import with: `use hex_conservative::test_hex_unwrap as hex;`
+/// For improved ergonomics import with: `use hex::test_hex_unwrap as hex;`
 #[macro_export]
 macro_rules! test_hex_unwrap (($hex:expr) => (<Vec<u8> as $crate::FromHex>::from_hex($hex).unwrap()));
 


### PR DESCRIPTION
Currently this crate is used using either `use hex-conservative::Foo` or using the `package` trick in the dependency specification to shorten it to `hex`. However the manifest provides a `lib` section for library renaming, we can use this so that the lib can be imported as `hex`.

With this applied the dependency specification becomes `hex = X.Y.Z` and the usage becomes `use hex::DisplayHex`.

This can be seen to work by checking the `fuzz` crate.

@stevenroose argued for this ages ago but at the time I did not manage to process the argument and thought this did not work - turns out he was right.