### PR TITLE
Add nth unit tests

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -207,39 +207,39 @@ mod tests {
     #[test]
     fn decode_iter_forward() {
         let hex = "deadbeef";
-        let v = vec![0xde, 0xad, 0xbe, 0xef];
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
 
         for (i, b) in HexToBytesIter::new(hex).unwrap().enumerate() {
-            assert_eq!(b.unwrap(), v[i]);
+            assert_eq!(b.unwrap(), bytes[i]);
         }
     }
 
     #[test]
     fn decode_iter_backward() {
         let hex = "deadbeef";
-        let v = vec![0xef, 0xbe, 0xad, 0xde];
+        let bytes = [0xef, 0xbe, 0xad, 0xde];
 
         for (i, b) in HexToBytesIter::new(hex).unwrap().rev().enumerate() {
-            assert_eq!(b.unwrap(), v[i]);
+            assert_eq!(b.unwrap(), bytes[i]);
         }
     }
 
     #[test]
     fn encode_iter() {
-        let v = vec![0xde, 0xad, 0xbe, 0xef];
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
         let hex = "deadbeef";
 
-        for (i, c) in BytesToHexIter::new(v.iter().cloned()).enumerate() {
+        for (i, c) in BytesToHexIter::new(bytes.iter().cloned()).enumerate() {
             assert_eq!(c, hex.chars().nth(i).unwrap());
         }
     }
 
     #[test]
     fn encode_iter_backwards() {
-        let v = vec![0xde, 0xad, 0xbe, 0xef];
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
         let hex = "efbeadde";
 
-        for (i, c) in BytesToHexIter::new(v.iter().cloned()).rev().enumerate() {
+        for (i, c) in BytesToHexIter::new(bytes.iter().cloned()).rev().enumerate() {
             assert_eq!(c, hex.chars().nth(i).unwrap());
         }
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -259,4 +259,60 @@ mod tests {
         let got = BytesToHexIter::new(bytes_iter).rev().collect::<String>();
         assert_eq!(got, hex);
     }
+
+    #[test]
+    fn hex_to_bytes_iter_nth() {
+        let hex = "deadbeef";
+        let bytes = [0xde_u8, 0xad, 0xbe, 0xef];
+        for (i, b) in bytes.iter().enumerate() {
+            let mut iter = HexToBytesIter::new(hex).expect("valid hex");
+            assert_eq!(iter.nth(i), Some(Ok(*b)));
+        }
+
+        let mut iter = HexToBytesIter::new(hex).expect("valid hex");
+        assert_eq!(iter.nth(bytes.len() + 1), None);
+    }
+
+    #[test]
+    fn bytes_to_hex_iter_nth() {
+        let bytes = [0xde_u8, 0xad, 0xbe, 0xef];
+        let hex = "deadbeef";
+        let iter = bytes.iter().copied();
+
+        for (i, c) in hex.chars().enumerate() {
+            let mut iter = BytesToHexIter::new(iter.clone());
+            assert_eq!(iter.nth(i), Some(c));
+        }
+        let mut iter = BytesToHexIter::new(iter);
+        assert_eq!(iter.nth(hex.len() + 1), None);
+    }
+
+    #[test]
+    fn hex_to_bytes_iter_nth_rev() {
+        let hex = "deadbeef";
+        let bytes = [0xef_u8, 0xbe, 0xad, 0xde];
+
+        for (i, b) in bytes.iter().enumerate() {
+            let iter = HexToBytesIter::new(hex).expect("valid hex");
+            assert_eq!(iter.rev().nth(i), Some(Ok(*b)));
+        }
+
+        let iter = HexToBytesIter::new(hex).expect("valid hex");
+        assert_eq!(iter.rev().nth(bytes.len() + 1), None);
+    }
+
+    #[test]
+    fn bytes_to_hex_iter_nth_rev() {
+        let bytes = [0xde_u8, 0xad, 0xbe, 0xef];
+        let hex = "efbeadde";
+        let iter = bytes.iter().copied();
+
+        for (i, c) in hex.chars().enumerate() {
+            let iter = BytesToHexIter::new(iter.clone());
+            assert_eq!(iter.rev().nth(i), Some(c));
+        }
+
+        let iter = BytesToHexIter::new(iter);
+        assert_eq!(iter.rev().nth(hex.len() + 1), None);
+    }
 }


### PR DESCRIPTION
Add some unit tests to prove that the default implementation of `nth` works correctly for `HexToBytesIter` and `BytesToHexIter`.

- Patch 1: Fixes clippy warnings introduced by a new version of clippy.
- Patch 2: Adds unit tests.

Resolve: #14