### PR TITLE
Fix CI 

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -3,6 +3,7 @@
 set -ex
 
 FEATURES="std alloc core2"
+MSRV="1\.48\.0"
 
 cargo --version
 rustc --version
@@ -11,6 +12,11 @@ rustc --version
 NIGHTLY=false
 if cargo --version | grep nightly >/dev/null; then
     NIGHTLY=true
+fi
+
+if cargo --version | grep ${MSRV}; then
+    # memchr 2.6.0 uses edition 2021
+    cargo update -p memchr --precise 2.5.0
 fi
 
 # Make all cargo invocations verbose

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -207,39 +207,39 @@ mod tests {
     #[test]
     fn decode_iter_forward() {
         let hex = "deadbeef";
-        let v = vec![0xde, 0xad, 0xbe, 0xef];
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
 
         for (i, b) in HexToBytesIter::new(hex).unwrap().enumerate() {
-            assert_eq!(b.unwrap(), v[i]);
+            assert_eq!(b.unwrap(), bytes[i]);
         }
     }
 
     #[test]
     fn decode_iter_backward() {
         let hex = "deadbeef";
-        let v = vec![0xef, 0xbe, 0xad, 0xde];
+        let bytes = [0xef, 0xbe, 0xad, 0xde];
 
         for (i, b) in HexToBytesIter::new(hex).unwrap().rev().enumerate() {
-            assert_eq!(b.unwrap(), v[i]);
+            assert_eq!(b.unwrap(), bytes[i]);
         }
     }
 
     #[test]
     fn encode_iter() {
-        let v = vec![0xde, 0xad, 0xbe, 0xef];
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
         let hex = "deadbeef";
 
-        for (i, c) in BytesToHexIter::new(v.iter().cloned()).enumerate() {
+        for (i, c) in BytesToHexIter::new(bytes.iter().cloned()).enumerate() {
             assert_eq!(c, hex.chars().nth(i).unwrap());
         }
     }
 
     #[test]
     fn encode_iter_backwards() {
-        let v = vec![0xde, 0xad, 0xbe, 0xef];
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
         let hex = "efbeadde";
 
-        for (i, c) in BytesToHexIter::new(v.iter().cloned()).rev().enumerate() {
+        for (i, c) in BytesToHexIter::new(bytes.iter().cloned()).rev().enumerate() {
             assert_eq!(c, hex.chars().nth(i).unwrap());
         }
     }


### PR DESCRIPTION
Fix CI by doing:

- Pin `memchr`
- Fix new clippy version warnings (remove unnecessary `vec`)

