### PR TITLE
Do some docs improvements

### DIFF
--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -4,9 +4,9 @@
 //!
 //! This is a low-level module, most uses should be satisfied by the `display` module instead.
 //!
-//! The main type of this module is [`BufEncoder`] which provides buffered hex encoding. Such is
-//! faster than the usual `write!(f, "{02x}", b)?` in a for loop because it reduces dynamic
-//! dispatch and decreases the number of allocations if a `String` is being created.
+//! The main type in this module is [`BufEncoder`] which provides buffered hex encoding.
+//! `BufEncoder` is faster than the usual `write!(f, "{02x}", b)?` in a for loop because it reduces
+//! dynamic dispatch and decreases the number of allocations if a `String` is being created.
 
 use core::borrow::Borrow;
 

--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -10,9 +10,11 @@
 
 use core::borrow::Borrow;
 
-pub use out_bytes::OutBytes;
-
 use super::Case;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::out_bytes::OutBytes;
 
 /// Trait for types that can be soundly converted to `OutBytes`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,15 +49,19 @@ mod error;
 mod iter;
 pub mod parse;
 
-pub use display::DisplayHex;
-pub use iter::{BytesToHexIter, HexToBytesIter};
-pub use parse::{FromHex, HexToArrayError, HexToBytesError};
-
 /// Reexports of extension traits.
 pub mod exts {
     pub use super::display::DisplayHex;
     pub use super::parse::FromHex;
 }
+
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use self::{
+    display::DisplayHex,
+    iter::{BytesToHexIter, HexToBytesIter},
+    parse::{FromHex, HexToArrayError, HexToBytesError},
+};
 
 /// Mainly reexports based on features.
 pub(crate) mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! ## Basic Usage
 //! ```
 //! # #[cfg(feature = "alloc")] {
-//! // Use the `package` key to improve import ergonomics (`hex` instead of `hex-conservative`).
+//! // In your manifest use the `package` key to improve import ergonomics.
 //! // hex = { package = "hex-conservative", version = "*" }
 //! # use hex_conservative as hex; // No need for this if using `package` as above.
 //! use hex::{DisplayHex, FromHex};


### PR DESCRIPTION
Do a few minor improvements, note please that patch one is not just docs it introduces the `rustfmt::skip` trick for public re-exports. Its part of "docs improvements" because it includes adding `doc(inline)`. The other two are trivial.