### PR TITLE
Add a prelude module

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -25,13 +25,13 @@
 //! assert_eq!(format!("{:0>8}", v.as_hex()), "0000abab");
 //!```
 
+#[cfg(feature = "alloc")]
+use alloc::string::String;
 use core::borrow::Borrow;
 use core::fmt;
 
 use super::Case;
 use crate::buf_encoder::{BufEncoder, FixedLenBuf, OutBytes};
-#[cfg(feature = "alloc")]
-use crate::prelude::*;
 
 /// Extension trait for types that can be displayed as hex.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! // In your manifest use the `package` key to improve import ergonomics.
 //! // hex = { package = "hex-conservative", version = "*" }
 //! # use hex_conservative as hex; // No need for this if using `package` as above.
-//! use hex::{DisplayHex, FromHex};
+//! use hex::prelude::*;
 //!
 //! // Decode an arbitrary length hex string into a vector.
 //! let v = Vec::from_hex("deadbeef").expect("valid hex digits");
@@ -49,10 +49,10 @@ mod error;
 mod iter;
 pub mod parse;
 
-/// Reexports of extension traits.
-pub mod exts {
-    pub use super::display::DisplayHex;
-    pub use super::parse::FromHex;
+/// Re-exports of the common crate traits.
+pub mod prelude {
+    #[doc(inline)]
+    pub use crate::{display::DisplayHex, parse::FromHex};
 }
 
 #[rustfmt::skip]                // Keep public re-exports separate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,12 +63,6 @@ pub use self::{
     parse::{FromHex, HexToArrayError, HexToBytesError},
 };
 
-/// Mainly reexports based on features.
-pub(crate) mod prelude {
-    #[cfg(feature = "alloc")]
-    pub(crate) use alloc::string::String;
-}
-
 /// Possible case of hex.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Case {


### PR DESCRIPTION
We really only have a few traits and types that users need to worry about when using this crate. Feels like `use hex::prelude::*` is ergonomic and unsurprising.
