### PR TITLE
Add serde module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,12 @@ alloc = []
 
 [dependencies]
 core2 = { version = "0.3.2", default_features = false, optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
+
 
 [dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [[example]]
 name = "hexy"
@@ -40,3 +44,7 @@ name = "wrap_array_display_hex_trait"
 
 [[example]]
 name = "wrap_array_fmt_traits"
+
+[[example]]
+name = "serde"
+required-features = ["std", "serde"]

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="std alloc core2"
+FEATURES="std alloc core2 serde"
 MSRV="1\.48\.0"
 
 cargo --version
@@ -15,6 +15,10 @@ if cargo --version | grep nightly >/dev/null; then
 fi
 
 if cargo --version | grep ${MSRV}; then
+    cargo update -p serde_json --precise 1.0.99
+    cargo update -p serde --precise 1.0.156
+    cargo update -p quote --precise 1.0.30
+    cargo update -p proc-macro2 --precise 1.0.63
     # memchr 2.6.0 uses edition 2021
     cargo update -p memchr --precise 2.5.0
 fi
@@ -32,6 +36,7 @@ if [ "$DO_LINT" = true ]
 then
     cargo clippy --all-features --all-targets -- -D warnings
     cargo clippy --locked --example hexy -- -D warnings
+    cargo clippy --locked --example serde --features=serde -- -D warnings
 fi
 
 if [ "$DO_FEATURE_MATRIX" = true ]; then

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -1,0 +1,29 @@
+//! Demonstrate how to use the serde module with struct fields.
+
+#![allow(clippy::disallowed_names)] // Foo is a valid name.
+
+use hex_conservative as hex;
+use serde::{Deserialize, Serialize};
+
+/// Abstracts over foo.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Foo {
+    // serialized as a hexadecimal string.
+    #[serde(with = "hex::serde")]
+    pub u: Vec<u8>,
+    // serialized as an array of decimal integers.
+    pub v: Vec<u8>,
+}
+
+fn main() {
+    let v = vec![0xde, 0xad, 0xbe, 0xef];
+
+    let foo = Foo { u: v.clone(), v };
+    let ser = serde_json::to_string(&foo).expect("failed to serialize foo");
+
+    // Prints:
+    //
+    //  foo: {"u":"deadbeef","v":[222,173,190,239]}
+    //
+    println!("\nfoo: {}", ser);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ pub mod display;
 mod error;
 mod iter;
 pub mod parse;
+#[cfg(feature = "serde")]
+pub mod serde;
 
 /// Re-exports of the common crate traits.
 pub mod prelude {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,108 @@
+//! Hex encoding with `serde`.
+//!
+//! The functions in this module de/serialize as hex _only_ when the serializer is human readable.
+//!
+//! # Examples
+//!
+//! ```
+//! # #[cfg(feature = "std")] {
+//! use hex_conservative as hex;
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Debug, Serialize, Deserialize)]
+//! struct Foo {
+//!     #[serde(with = "hex::serde")]
+//!     bar: Vec<u8>,
+//! }
+//! # }
+//! ```
+
+use core::fmt;
+use core::marker::PhantomData;
+
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::prelude::*;
+
+/// Serializes `data` as a hex string using lowercase characters.
+///
+/// We only serialize as hex if the serializer is human readable, if not we call through to the
+/// `Serialize` implementation for `data`.
+pub fn serialize<S, T>(data: T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize + DisplayHex,
+{
+    serialize_lower(data, s)
+}
+
+/// Serializes `data` as a hex string using lowercase characters.
+///
+/// We only serialize as hex if the serializer is human readable, if not we call through to the
+/// `Serialize` implementation for `data`.
+pub fn serialize_lower<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize + DisplayHex,
+{
+    // Don't do anything special when not human readable.
+    if !serializer.is_human_readable() {
+        serde::Serialize::serialize(&data, serializer)
+    } else {
+        serializer.collect_str(&format_args!("{:x}", data.as_hex()))
+    }
+}
+
+/// Serializes `data` as hex string using uppercase characters.
+///
+/// We only serialize as hex if the serializer is human readable, if not we call through to the
+/// `Serialize` implementation for `data`.
+pub fn serialize_upper<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize + DisplayHex,
+{
+    // Don't do anything special when not human readable.
+    if !serializer.is_human_readable() {
+        serde::Serialize::serialize(&data, serializer)
+    } else {
+        serializer.collect_str(&format_args!("{:X}", data.as_hex()))
+    }
+}
+
+/// Deserializes a hex string into raw bytes.
+///
+/// Allows upper, lower, and mixed case characters (e.g. `a5b3c1`, `A5B3C1` and `A5b3C1`).
+///
+/// We only deserialize from hex if the serializer is human readable, if not we call through to the
+/// `Deserialize` implementation for `T`.
+pub fn deserialize<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + FromHex,
+{
+    struct HexVisitor<T>(PhantomData<T>);
+
+    impl<'de, T> Visitor<'de> for HexVisitor<T>
+    where
+        T: FromHex,
+    {
+        type Value = T;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("an ASCII hex string")
+        }
+
+        fn visit_str<E: Error>(self, data: &str) -> Result<Self::Value, E> {
+            FromHex::from_hex(data).map_err(Error::custom)
+        }
+    }
+
+    // Don't do anything special when not human readable.
+    if !d.is_human_readable() {
+        serde::Deserialize::deserialize(d)
+    } else {
+        d.deserialize_map(HexVisitor(PhantomData))
+    }
+}


### PR DESCRIPTION
Add a `serde` module and feature gate it behind the "serde" feature as is customary. Add an example showing how to use the new module to serialize struct fields as hex.
    
Fix: #6
