### PR TITLE
Add Kix's name to the authors list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hex-conservative"
 version = "0.1.1"
-authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"
 documentation = "https://docs.rs/hex-conservative/"


### PR DESCRIPTION
If one looks at crates.io or the git index it looks like I wrote this crate but that is wholeheartedly untrue, Kix wrote almost all the code in this crate IIRC. I just pulled it all out of `rust-bitcoin`.

Put Kixunil's name at the front of the author's list. Leave Andrew's there in second place because he is the crate owner, and reviewed everything. Omit my name because I have only chopped and changed trivial things and am only likely to polish things going forwards.