### PR TITLE
Add `InvalidLengthError`

### DIFF
--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -117,7 +117,7 @@ impl<'a> fmt::UpperHex for DisplayALittleBitHexy<'a> {
 }
 
 /// Example Error.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     /// Conversion error while parsing hex string.
     Conversion(HexToBytesError),


### PR DESCRIPTION
Draft for discussion. This wraps the internals of the `HexToArrayError` as suggested in #13.

Note: Please don't take this as argumentative, the purpose is to get right to the bottom of things so once we start executing whatever we decide on its done right. Remember, we are setting precedent for all the other crates in the `rust-bitcoin` org.

I personally think this is going too far for a two reasons, primarily (1)

1. This does not save us from having to do a major release when we add new data to the error types because most likely that will lead to a change in the `Display` output which is a major breaking change.
2. We already have quite a lot of error boilerplate, admittedly this is write-once code but still it is there, its still a liability. This new wrapping style introduces loads more boilerplate, which means loads of work, which likely no one else is going to do except me - and its boring as bat shit. If we are going to go for this I'd like everyone to be _really_ confident its worth it. Also everytime we have to make a tiny change to some stylistic error thing it has to be done in many places, and I never get it right first time.


