### PR TITLE
Hide all error internals

### DIFF
--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -117,7 +117,7 @@ impl<'a> fmt::UpperHex for DisplayALittleBitHexy<'a> {
 }
 
 /// Example Error.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     /// Conversion error while parsing hex string.
     Conversion(HexToBytesError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
+use core::fmt;
+
 /// Formats error.
 ///
 /// If `std` feature is OFF appends error source (delimited by `: `). We do this because
@@ -20,4 +22,73 @@ macro_rules! write_err {
             }
         }
     }
+}
+
+/// Hex decoding error.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HexToBytesError {
+    /// Non-hexadecimal character.
+    InvalidChar(u8),
+    /// Purported hex string had odd length.
+    OddLengthString(usize),
+}
+
+impl fmt::Display for HexToBytesError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use HexToBytesError::*;
+
+        match *self {
+            InvalidChar(ch) => write!(f, "invalid hex character {}", ch),
+            OddLengthString(ell) => write!(f, "odd hex string length {}", ell),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HexToBytesError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use HexToBytesError::*;
+
+        match self {
+            InvalidChar(_) | OddLengthString(_) => None,
+        }
+    }
+}
+
+/// Hex decoding error.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HexToArrayError {
+    /// Conversion error while parsing hex string.
+    Conversion(HexToBytesError),
+    /// Tried to parse fixed-length hash from a string with the wrong length (got, want).
+    InvalidLength(usize, usize),
+}
+
+impl fmt::Display for HexToArrayError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use HexToArrayError::*;
+
+        match *self {
+            Conversion(ref e) => crate::write_err!(f, "conversion error"; e),
+            InvalidLength(got, want) =>
+                write!(f, "bad hex string length {} (expected {})", got, want),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HexToArrayError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use HexToArrayError::*;
+
+        match *self {
+            Conversion(ref e) => Some(e),
+            InvalidLength(_, _) => None,
+        }
+    }
+}
+
+impl From<HexToBytesError> for HexToArrayError {
+    #[inline]
+    fn from(e: HexToBytesError) -> Self { Self::Conversion(e) }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -8,6 +8,9 @@ use core::{fmt, str};
 use crate::alloc::vec::Vec;
 use crate::iter::HexToBytesIter;
 
+#[rustfmt::skip]                // Keep public re-exports separate.
+pub use crate::error::{HexToBytesError, HexToArrayError};
+
 /// Trait for objects that can be deserialized from hex strings.
 pub trait FromHex: Sized {
     /// Error type returned while parsing hex string.
@@ -34,37 +37,6 @@ impl FromHex for Vec<u8> {
         I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         iter.collect()
-    }
-}
-
-/// Hex decoding error.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum HexToBytesError {
-    /// Non-hexadecimal character.
-    InvalidChar(u8),
-    /// Purported hex string had odd length.
-    OddLengthString(usize),
-}
-
-impl fmt::Display for HexToBytesError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use HexToBytesError::*;
-
-        match *self {
-            InvalidChar(ch) => write!(f, "invalid hex character {}", ch),
-            OddLengthString(ell) => write!(f, "odd hex string length {}", ell),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for HexToBytesError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use HexToBytesError::*;
-
-        match self {
-            InvalidChar(_) | OddLengthString(_) => None,
-        }
     }
 }
 
@@ -112,44 +84,6 @@ impl_fromhex_array!(128);
 impl_fromhex_array!(256);
 impl_fromhex_array!(384);
 impl_fromhex_array!(512);
-
-/// Hex decoding error.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum HexToArrayError {
-    /// Conversion error while parsing hex string.
-    Conversion(HexToBytesError),
-    /// Tried to parse fixed-length hash from a string with the wrong length (got, want).
-    InvalidLength(usize, usize),
-}
-
-impl fmt::Display for HexToArrayError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use HexToArrayError::*;
-
-        match *self {
-            Conversion(ref e) => crate::write_err!(f, "conversion error"; e),
-            InvalidLength(got, want) =>
-                write!(f, "bad hex string length {} (expected {})", got, want),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for HexToArrayError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use HexToArrayError::*;
-
-        match *self {
-            Conversion(ref e) => Some(e),
-            InvalidLength(_, _) => None,
-        }
-    }
-}
-
-impl From<HexToBytesError> for HexToArrayError {
-    #[inline]
-    fn from(e: HexToBytesError) -> Self { Self::Conversion(e) }
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Before we do v1.0 we want to hide all the error internals so that we can modify/improve them without breaking the public API.

Please pay particular attention to the `Display` strings because we they are considered part of the public API so we don't want to change them willy-nilly. Of note, because the enums have inner structs it was difficult to not duplicate the error message.


Resolve: #42