### PR TITLE
Tracking PR for release `v0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-# unrelease
 
-- Bump MSRV to 1.56.1
+# 0.2.0 - 2023-11-16
+
+- Bump MSRV to 1.56.1 [#55](https://github.com/rust-bitcoin/hex-conservative/pull/55)
+- Revamp `BufEncoder` [#52](https://github.com/rust-bitcoin/hex-conservative/pull/52)
+- Hide all error internals [#44](https://github.com/rust-bitcoin/hex-conservative/pull/44)
+- Change `FromHex` associated error type to `Error` [#54](https://github.com/rust-bitcoin/hex-conservative/pull/54)
+- Add a prelude module [#36](https://github.com/rust-bitcoin/hex-conservative/pull/36)
+- Add serde module [#37](https://github.com/rust-bitcoin/hex-conservative/pull/37)
 
 # 0.1.1 - 2023-07-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.1.1" }
+hex = { path = "..", package = "hex-conservative" }
 
 [[bin]]
 name = "hex"

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -21,7 +21,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.2.0" }
+hex = { path = "..", package = "hex-conservative" }
 EOF
 
 for targetFile in $(listTargetFiles); do


### PR DESCRIPTION
Once `io` is released and #56 goes in I rekon we can cut another release.

Needs the public API script running.


 