### PR TITLE
Use correct syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ std = ["alloc"]
 alloc = []
 
 [dependencies]
-core2 = { version = "0.3.2", default_features = false, optional = true }
+core2 = { version = "0.3.2", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
 


### PR DESCRIPTION
The manifest should use a hyphen not an underscore.

Fix: #47