### PR TITLE
Add doc_auto_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions
 #![warn(missing_docs)]
 


### PR DESCRIPTION
So that the HTML rendering of our docs marks feature gated code enable `doc_auto_cfg` when we build docs for docsrs.