### PR TITLE
Add support for prefixes to the `FromHex` trait

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -1,41 +1,55 @@
+#[non_exhaustive] pub enum hex_conservative::parse::PrefixedError<E>
+#[non_exhaustive] pub struct hex_conservative::parse::MissingPrefixError(_)
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::parse::MissingPrefixError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::parse::MissingPrefixError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::parse::MissingPrefixError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
 impl core::default::Default for hex_conservative::Case
 impl core::error::Error for hex_conservative::HexToArrayError
 impl core::error::Error for hex_conservative::HexToBytesError
+impl core::error::Error for hex_conservative::parse::MissingPrefixError
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::parse::MissingPrefixError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::parse::MissingPrefixError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::parse::MissingPrefixError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::parse::MissingPrefixError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::parse::MissingPrefixError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::MissingPrefixError
 impl hex_conservative::parse::FromHex for [u8; 10]
 impl hex_conservative::parse::FromHex for [u8; 128]
 impl hex_conservative::parse::FromHex for [u8; 12]
@@ -114,6 +128,19 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
 impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
 impl<'a> std::io::Read for hex_conservative::HexToBytesIter<'a>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::parse::PrefixedError<E>
+impl<E> core::convert::From<E> for hex_conservative::parse::PrefixedError<E>
+impl<E> core::error::Error for hex_conservative::parse::PrefixedError<E> where E: core::error::Error + 'static
+impl<E> core::marker::Send for hex_conservative::parse::PrefixedError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E> core::marker::Sync for hex_conservative::parse::PrefixedError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::parse::PrefixedError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -204,7 +231,10 @@ pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative:
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
 pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
 pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -238,7 +268,18 @@ pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_cons
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
+pub fn hex_conservative::parse::MissingPrefixError::clone(&self) -> hex_conservative::parse::MissingPrefixError
+pub fn hex_conservative::parse::MissingPrefixError::eq(&self, other: &hex_conservative::parse::MissingPrefixError) -> bool
+pub fn hex_conservative::parse::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::clone(&self) -> hex_conservative::parse::PrefixedError<E>
+pub fn hex_conservative::parse::PrefixedError<E>::eq(&self, other: &hex_conservative::parse::PrefixedError<E>) -> bool
+pub fn hex_conservative::parse::PrefixedError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::from(e: E) -> Self
+pub fn hex_conservative::parse::PrefixedError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
@@ -246,7 +287,10 @@ pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_cons
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub fn hex_conservative::serde::deserialize<'de, D, T>(d: D) -> core::result::Result<T, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>, T: serde::de::Deserialize<'de> + hex_conservative::parse::FromHex
 pub fn hex_conservative::serde::serialize<S, T>(data: T, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
 pub fn hex_conservative::serde::serialize_lower<S, T>(data: T, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
@@ -261,6 +305,8 @@ pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexTo
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
 pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::PrefixedError::MissingPrefix(hex_conservative::parse::MissingPrefixError)
+pub hex_conservative::parse::PrefixedError::ParseHex(E)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!

--- a/api/alloc.txt
+++ b/api/alloc.txt
@@ -1,39 +1,52 @@
+#[non_exhaustive] pub enum hex_conservative::parse::PrefixedError<E>
+#[non_exhaustive] pub struct hex_conservative::parse::MissingPrefixError(_)
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::parse::MissingPrefixError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::parse::MissingPrefixError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::parse::MissingPrefixError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::parse::MissingPrefixError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::parse::MissingPrefixError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::parse::MissingPrefixError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::parse::MissingPrefixError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::parse::MissingPrefixError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::MissingPrefixError
 impl hex_conservative::parse::FromHex for [u8; 10]
 impl hex_conservative::parse::FromHex for [u8; 128]
 impl hex_conservative::parse::FromHex for [u8; 12]
@@ -111,6 +124,18 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
 impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::parse::PrefixedError<E>
+impl<E> core::convert::From<E> for hex_conservative::parse::PrefixedError<E>
+impl<E> core::marker::Send for hex_conservative::parse::PrefixedError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E> core::marker::Sync for hex_conservative::parse::PrefixedError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::parse::PrefixedError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -201,7 +226,10 @@ pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative:
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
 pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
 pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -232,7 +260,17 @@ pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_cons
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
+pub fn hex_conservative::parse::MissingPrefixError::clone(&self) -> hex_conservative::parse::MissingPrefixError
+pub fn hex_conservative::parse::MissingPrefixError::eq(&self, other: &hex_conservative::parse::MissingPrefixError) -> bool
+pub fn hex_conservative::parse::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::clone(&self) -> hex_conservative::parse::PrefixedError<E>
+pub fn hex_conservative::parse::PrefixedError<E>::eq(&self, other: &hex_conservative::parse::PrefixedError<E>) -> bool
+pub fn hex_conservative::parse::PrefixedError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::from(e: E) -> Self
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
@@ -240,7 +278,10 @@ pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_cons
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
@@ -251,6 +292,8 @@ pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexTo
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
 pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::PrefixedError::MissingPrefix(hex_conservative::parse::MissingPrefixError)
+pub hex_conservative::parse::PrefixedError::ParseHex(E)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!

--- a/api/core2.txt
+++ b/api/core2.txt
@@ -1,39 +1,52 @@
+#[non_exhaustive] pub enum hex_conservative::parse::PrefixedError<E>
+#[non_exhaustive] pub struct hex_conservative::parse::MissingPrefixError()
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::parse::MissingPrefixError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::parse::MissingPrefixError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::parse::MissingPrefixError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::parse::MissingPrefixError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::parse::MissingPrefixError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::parse::MissingPrefixError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::parse::MissingPrefixError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::parse::MissingPrefixError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::MissingPrefixError
 impl hex_conservative::parse::FromHex for [u8; 10]
 impl hex_conservative::parse::FromHex for [u8; 128]
 impl hex_conservative::parse::FromHex for [u8; 12]
@@ -110,6 +123,18 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::parse::PrefixedError<E>
+impl<E> core::convert::From<E> for hex_conservative::parse::PrefixedError<E>
+impl<E> core::marker::Send for hex_conservative::parse::PrefixedError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E> core::marker::Sync for hex_conservative::parse::PrefixedError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::parse::PrefixedError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -193,7 +218,10 @@ pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut 
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
 pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
 pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -221,11 +249,24 @@ pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core:
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
+pub fn hex_conservative::parse::MissingPrefixError::clone(&self) -> hex_conservative::parse::MissingPrefixError
+pub fn hex_conservative::parse::MissingPrefixError::eq(&self, other: &hex_conservative::parse::MissingPrefixError) -> bool
+pub fn hex_conservative::parse::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::clone(&self) -> hex_conservative::parse::PrefixedError<E>
+pub fn hex_conservative::parse::PrefixedError<E>::eq(&self, other: &hex_conservative::parse::PrefixedError<E>) -> bool
+pub fn hex_conservative::parse::PrefixedError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::from(e: E) -> Self
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
@@ -236,6 +277,8 @@ pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexTo
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
 pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::PrefixedError::MissingPrefix(hex_conservative::parse::MissingPrefixError)
+pub hex_conservative::parse::PrefixedError::ParseHex(E)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!

--- a/api/default-features.txt
+++ b/api/default-features.txt
@@ -1,41 +1,55 @@
+#[non_exhaustive] pub enum hex_conservative::parse::PrefixedError<E>
+#[non_exhaustive] pub struct hex_conservative::parse::MissingPrefixError(_)
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::parse::MissingPrefixError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::parse::MissingPrefixError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::parse::MissingPrefixError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
 impl core::default::Default for hex_conservative::Case
 impl core::error::Error for hex_conservative::HexToArrayError
 impl core::error::Error for hex_conservative::HexToBytesError
+impl core::error::Error for hex_conservative::parse::MissingPrefixError
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::parse::MissingPrefixError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::parse::MissingPrefixError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::parse::MissingPrefixError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::parse::MissingPrefixError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::parse::MissingPrefixError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::MissingPrefixError
 impl hex_conservative::parse::FromHex for [u8; 10]
 impl hex_conservative::parse::FromHex for [u8; 128]
 impl hex_conservative::parse::FromHex for [u8; 12]
@@ -114,6 +128,19 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
 impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
 impl<'a> std::io::Read for hex_conservative::HexToBytesIter<'a>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::parse::PrefixedError<E>
+impl<E> core::convert::From<E> for hex_conservative::parse::PrefixedError<E>
+impl<E> core::error::Error for hex_conservative::parse::PrefixedError<E> where E: core::error::Error + 'static
+impl<E> core::marker::Send for hex_conservative::parse::PrefixedError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E> core::marker::Sync for hex_conservative::parse::PrefixedError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::parse::PrefixedError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -204,7 +231,10 @@ pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative:
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
 pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
 pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -238,7 +268,18 @@ pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_cons
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
+pub fn hex_conservative::parse::MissingPrefixError::clone(&self) -> hex_conservative::parse::MissingPrefixError
+pub fn hex_conservative::parse::MissingPrefixError::eq(&self, other: &hex_conservative::parse::MissingPrefixError) -> bool
+pub fn hex_conservative::parse::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::clone(&self) -> hex_conservative::parse::PrefixedError<E>
+pub fn hex_conservative::parse::PrefixedError<E>::eq(&self, other: &hex_conservative::parse::PrefixedError<E>) -> bool
+pub fn hex_conservative::parse::PrefixedError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::from(e: E) -> Self
+pub fn hex_conservative::parse::PrefixedError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
@@ -246,7 +287,10 @@ pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_cons
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex<S: core::convert::AsRef<str> + core::convert::Into<alloc::string::String>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
@@ -257,6 +301,8 @@ pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexTo
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
 pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::PrefixedError::MissingPrefix(hex_conservative::parse::MissingPrefixError)
+pub hex_conservative::parse::PrefixedError::ParseHex(E)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!

--- a/api/no-default-features.txt
+++ b/api/no-default-features.txt
@@ -1,39 +1,52 @@
+#[non_exhaustive] pub enum hex_conservative::parse::PrefixedError<E>
+#[non_exhaustive] pub struct hex_conservative::parse::MissingPrefixError()
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::parse::MissingPrefixError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::parse::MissingPrefixError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::parse::MissingPrefixError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::parse::MissingPrefixError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::parse::MissingPrefixError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::parse::MissingPrefixError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::parse::MissingPrefixError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::parse::MissingPrefixError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::MissingPrefixError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::MissingPrefixError
 impl hex_conservative::parse::FromHex for [u8; 10]
 impl hex_conservative::parse::FromHex for [u8; 128]
 impl hex_conservative::parse::FromHex for [u8; 12]
@@ -109,6 +122,18 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::parse::PrefixedError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::parse::PrefixedError<E>
+impl<E> core::convert::From<E> for hex_conservative::parse::PrefixedError<E>
+impl<E> core::marker::Send for hex_conservative::parse::PrefixedError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::parse::PrefixedError<E>
+impl<E> core::marker::Sync for hex_conservative::parse::PrefixedError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::parse::PrefixedError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::parse::PrefixedError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -192,7 +217,10 @@ pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut 
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::FromHex::from_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
 pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
 pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -219,11 +247,24 @@ pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core:
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
+pub fn hex_conservative::parse::MissingPrefixError::clone(&self) -> hex_conservative::parse::MissingPrefixError
+pub fn hex_conservative::parse::MissingPrefixError::eq(&self, other: &hex_conservative::parse::MissingPrefixError) -> bool
+pub fn hex_conservative::parse::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::clone(&self) -> hex_conservative::parse::PrefixedError<E>
+pub fn hex_conservative::parse::PrefixedError<E>::eq(&self, other: &hex_conservative::parse::PrefixedError<E>) -> bool
+pub fn hex_conservative::parse::PrefixedError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::parse::PrefixedError<E>::from(e: E) -> Self
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex<S: core::convert::AsRef<str>>(s: S) -> core::result::Result<Self, hex_conservative::parse::PrefixedError<Self::Error>>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
@@ -234,6 +275,8 @@ pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexTo
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
 pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::PrefixedError::MissingPrefix(hex_conservative::parse::MissingPrefixError)
+pub hex_conservative::parse::PrefixedError::ParseHex(E)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -19,7 +19,7 @@ fn main() {
     #[cfg(feature = "alloc")]
     {
         let hex = hexy.to_lower_hex_string();
-        let from_hex = ALittleBitHexy::from_hex(&hex).expect("failed to parse hex");
+        let from_hex = ALittleBitHexy::from_hex(hex).expect("failed to parse hex");
         assert_eq!(from_hex, hexy);
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,9 +5,10 @@
 use core::{fmt, str};
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
-use crate::alloc::vec::Vec;
+use crate::alloc::{string::String, vec::Vec};
 use crate::error::InvalidLengthError;
 use crate::iter::HexToBytesIter;
+use crate::write_err;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use crate::error::{HexToBytesError, HexToArrayError};
@@ -22,9 +23,64 @@ pub trait FromHex: Sized {
     where
         I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator;
 
+    /// Parses provided string as hex explicitly requiring there to not be a `0x` prefix.
+    ///
+    /// This is not recommended for user-supplied inputs because of possible confusion with decimals.
+    /// It should be only used for existing protocols which always encode values as hex without 0x prefix.
+    #[rustfmt::skip]
+    fn from_hex<
+        #[cfg(feature = "alloc")] S: AsRef<str> + Into<String>,
+        #[cfg(not(feature = "alloc"))] S: AsRef<str>,
+    >(s: S) -> Result<Self, Self::Error> {
+        Self::from_no_prefix_hex(s)
+    }
+
     /// Produces an object from a hex string.
-    fn from_hex(s: &str) -> Result<Self, Self::Error> {
-        Self::from_byte_iter(HexToBytesIter::new(s)?)
+    ///
+    /// Accepts an input string either with `0x` prefix or without, if you require specific handling
+    /// of the prefix see [`Self::from_prefixed_hex`] and [`Self::from_no_prefix_hex`].
+    #[rustfmt::skip]
+    fn from_maybe_prefixed_hex<
+        #[cfg(feature = "alloc")] S: AsRef<str> + Into<String>,
+        #[cfg(not(feature = "alloc"))] S: AsRef<str>,
+    >(s: S) -> Result<Self, Self::Error> {
+        if s.as_ref().starts_with("0x") {
+            Self::from_no_prefix_hex(s.as_ref().trim_start_matches("0x"))
+        } else {
+            Self::from_no_prefix_hex(s)
+        }
+    }
+
+    /// Parses provided string as hex explicitly requiring there to not be a `0x` prefix.
+    ///
+    /// This is not recommended for user-supplied inputs because of possible confusion with decimals.
+    /// It should be only used for existing protocols which always encode values as hex without 0x prefix.
+    #[rustfmt::skip]
+    fn from_no_prefix_hex<
+        #[cfg(feature = "alloc")] S: AsRef<str> + Into<String>,
+        #[cfg(not(feature = "alloc"))] S: AsRef<str>,
+    >(s: S) -> Result<Self, Self::Error> {
+        Self::from_byte_iter(HexToBytesIter::new(s.as_ref())?)
+    }
+
+    /// Parses provided string as hex requiring 0x prefix.
+    ///
+    /// This is intended for user-supplied inputs or already-existing protocols in which 0x prefix is used.
+    #[rustfmt::skip]
+    fn from_prefixed_hex<
+        #[cfg(feature = "alloc")] S: AsRef<str> + Into<String>,
+        #[cfg(not(feature = "alloc"))] S: AsRef<str>,
+    >(s: S) -> Result<Self, PrefixedError<Self::Error>> {
+        use PrefixedError::*;
+
+        if !s.as_ref().starts_with("0x") {
+            #[cfg(feature = "alloc")]
+            return Err(MissingPrefix(MissingPrefixError(s.into())));
+            #[cfg(not(feature = "alloc"))]
+            return Err(MissingPrefix(MissingPrefixError()));
+        } else {
+            Ok(Self::from_no_prefix_hex(s.as_ref().trim_start_matches("0x"))?)
+        }
     }
 }
 
@@ -85,6 +141,65 @@ impl_fromhex_array!(128);
 impl_fromhex_array!(256);
 impl_fromhex_array!(384);
 impl_fromhex_array!(512);
+
+/// Hex parsing error
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PrefixedError<E> {
+    /// The input was not a valid hex string, contains the error that occurred while parsing.
+    ParseHex(E),
+    /// The input is missing `0x` prefix, contains the invalid input.
+    MissingPrefix(MissingPrefixError),
+}
+
+impl<E> From<E> for PrefixedError<E> {
+    fn from(e: E) -> Self { PrefixedError::ParseHex(e) }
+}
+
+impl<E: fmt::Display> fmt::Display for PrefixedError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use PrefixedError::*;
+
+        match *self {
+            ParseHex(ref e) => write_err!(f, "failed to parse hex string"; e),
+            MissingPrefix(ref e) => write_err!(f, "missing prefix"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E> std::error::Error for PrefixedError<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use PrefixedError::*;
+
+        match *self {
+            ParseHex(ref e) => Some(e),
+            MissingPrefix(ref e) => Some(e),
+        }
+    }
+}
+
+/// Hex string was missing the `0x` prefix.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingPrefixError(#[cfg(feature = "alloc")] String);
+
+impl fmt::Display for MissingPrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[cfg(feature = "alloc")]
+        let res = write!(f, "the input value `{}` is missing the `0x` prefix", self.0);
+        #[cfg(not(feature = "alloc"))]
+        let res = write!(f, "input string is missing the `0x` prefix");
+
+        res
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MissingPrefixError {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Draft because error handling of `FromHex` needs attention and also I can't work out how to print backwards in `hashes` anymore.

Add support for parsing prefixed strings as well as requiring the presence or absence of the prefix.

This code was copied from `rust-bitcoin`. The error type was re-named.