### PR TITLE
Return specific error

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -1,41 +1,54 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::error::Error for hex_conservative::HexToArrayError
 impl core::error::Error for hex_conservative::HexToBytesError
+impl core::error::Error for hex_conservative::OddLengthStringError
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -177,13 +190,18 @@ pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -220,11 +238,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -237,6 +255,7 @@ pub mod hex_conservative::prelude
 pub mod hex_conservative::serde
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/alloc.txt
+++ b/api/alloc.txt
@@ -1,39 +1,51 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -173,11 +185,15 @@ pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesEr
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -210,11 +226,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -226,6 +242,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/core2.txt
+++ b/api/core2.txt
@@ -1,39 +1,51 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -165,12 +177,16 @@ pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesEr
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> core2::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -195,11 +211,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -211,6 +227,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/default-features.txt
+++ b/api/default-features.txt
@@ -1,41 +1,54 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::error::Error for hex_conservative::HexToArrayError
 impl core::error::Error for hex_conservative::HexToBytesError
+impl core::error::Error for hex_conservative::OddLengthStringError
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -177,13 +190,18 @@ pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -216,11 +234,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -232,6 +250,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/no-default-features.txt
+++ b/api/no-default-features.txt
@@ -1,39 +1,51 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -164,11 +176,15 @@ pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesEr
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -193,11 +209,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -209,6 +225,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -10,10 +10,10 @@ use std::io;
 #[cfg(all(feature = "core2", not(feature = "std")))]
 use core2::io;
 
-use crate::error::{InvalidCharError, OddLengthStringError};
+use crate::error::InvalidCharError;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::HexToBytesError;
+pub use crate::error::{HexToBytesError, OddLengthStringError};
 
 /// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
 pub struct HexToBytesIter<'a> {
@@ -34,9 +34,9 @@ impl<'a> HexToBytesIter<'a> {
     ///
     /// If the input string is of odd length.
     #[inline]
-    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, HexToBytesError> {
+    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, OddLengthStringError> {
         if s.len() % 2 != 0 {
-            Err(OddLengthStringError { len: s.len() }.into())
+            Err(OddLengthStringError { len: s.len() })
         } else {
             Ok(HexToBytesIter { iter: s.bytes() })
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) use table::Table;
 #[doc(inline)]
 pub use self::{
     display::DisplayHex,
-    iter::{BytesToHexIter, HexToBytesIter},
+    iter::{BytesToHexIter, HexToBytesIter, OddLengthStringError},
     parse::{FromHex, HexToArrayError, HexToBytesError},
 };
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,7 +26,8 @@ pub trait FromHex: Sized {
 
     /// Produces an object from a hex string.
     fn from_hex(s: &str) -> Result<Self, Self::Error> {
-        Self::from_byte_iter(HexToBytesIter::new(s)?)
+        let iter = HexToBytesIter::new(s).map_err(Into::into)?;
+        Self::from_byte_iter(iter)
     }
 }
 


### PR DESCRIPTION
The `HexToByesIter::new` constructor can only fail in a single manner, return the specific error type for this failure instead of the more general error enum.