### PR TITLE
Release tracking PR: `v0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
-# unrelease
+# 0.2.0 - 2024-02-27
+
+### Breaking changes
+
+There are a bunch of breaking changes in this release, including:
+
+- Re-write the `FromHex` trait [#80](https://github.com/rust-bitcoin/hex-conservative/pull/80)
+- Revamp `BufEncoder` [#52](https://github.com/rust-bitcoin/hex-conservative/pull/52)
+- A bunch of public errors have changed.
+
+### Other improvements
 
 - Bump MSRV to 1.56.1
+- For improved ergonomics, add a prelude module [#36](https://github.com/rust-bitcoin/hex-conservative/pull/36)
+- Add a `serde` module [#37](https://github.com/rust-bitcoin/hex-conservative/pull/37)
+- Remove arbitrary padding limit [#41](https://github.com/rust-bitcoin/hex-conservative/pull/41)
+- Make `fmt_hex_exact` honour `Formatter::precision`[#81](https://github.com/rust-bitcoin/hex-conservative/pull/81)
+
+### Improve error handling
+
+- Update the derives on error types [#31](https://github.com/rust-bitcoin/hex-conservative/pull/31)
+- Hide error internal [#44](https://github.com/rust-bitcoin/hex-conservative/pull/44)
+- Return specific error from `HexToByesIter::new` [#62](https://github.com/rust-bitcoin/hex-conservative/pull/62)
 
 # 0.1.1 - 2023-07-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.1.1" }
+hex = { path = "..", package = "hex-conservative", version = "0.2.0" }
 
 [[bin]]
 name = "hex"


### PR DESCRIPTION
Add changelog entry and bump the version.

Note that during the 0.1.1 release I updated `fuzz/generate-files.sh` incorrectly so it has 0.2.0 in it already.

See commit: `42f3cda Bump version to 0.1.1`

### Testing

Tested in a rust-bitcoin POC PR: https://github.com/rust-bitcoin/rust-bitcoin/pull/2473.
