### PR TITLE
CI: Run rustfmt and clippy as separate jobs

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -21,7 +21,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Running test script
         env:
-          DO_LINT: true
           DO_DOCS: true
           DO_FEATURE_MATRIX: true
         run: ./contrib/test.sh
@@ -51,7 +50,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       - name: Running test script
         env:
-          DO_FMT: true
           DO_DOCSRS: true
         run: ./contrib/test.sh
 
@@ -68,6 +66,36 @@ jobs:
       - name: Running test script
         env:
           DO_FEATURE_MATRIX: true
+        run: ./contrib/test.sh
+
+  Lint:
+    name: Clippy - stable toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Running test script
+        env:
+          DO_LINT: true
+        run: ./contrib/test.sh
+
+  Fmt:
+    name: Format - nightly toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Running test script
+        env:
+          DO_FMT: true
         run: ./contrib/test.sh
 
   Arch32bit:


### PR DESCRIPTION
It is easier to see what went wrong with CI if the jobs are separate.

Pull the linting and the formatting out into separate jobs.

Fix: #53