### PR TITLE
Add `FromHex::as_hex_backwards`

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -1,54 +1,100 @@
+#[non_exhaustive] pub struct hex_conservative::error::ContainsPrefixError
+#[non_exhaustive] pub struct hex_conservative::error::MissingPrefixError
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::ContainsPrefixError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::MissingPrefixError
+impl core::clone::Clone for hex_conservative::error::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::MissingPrefixError
+impl core::cmp::Eq for hex_conservative::error::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::MissingPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthStringError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
 impl core::default::Default for hex_conservative::Case
-impl core::error::Error for hex_conservative::HexToArrayError
-impl core::error::Error for hex_conservative::HexToBytesError
-impl core::error::Error for hex_conservative::OddLengthStringError
+impl core::error::Error for hex_conservative::error::ContainsPrefixError
+impl core::error::Error for hex_conservative::error::HexToArrayError
+impl core::error::Error for hex_conservative::error::InvalidCharError
+impl core::error::Error for hex_conservative::error::InvalidLengthError
+impl core::error::Error for hex_conservative::error::MissingPrefixError
+impl core::error::Error for hex_conservative::error::OddLengthStringError
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::MissingPrefixError
+impl core::fmt::Debug for hex_conservative::error::OddLengthStringError
+impl core::fmt::Display for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::MissingPrefixError
+impl core::fmt::Display for hex_conservative::error::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthStringError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::ContainsPrefixError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::MissingPrefixError
+impl core::marker::Send for hex_conservative::error::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::ContainsPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::MissingPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::ContainsPrefixError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::MissingPrefixError
+impl core::marker::Sync for hex_conservative::error::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::ContainsPrefixError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::MissingPrefixError
+impl core::marker::Unpin for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthStringError
+impl hex_conservative::error::ContainsPrefixError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::MissingPrefixError
+impl hex_conservative::error::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -108,6 +154,47 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
 impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
 impl<'a> std::io::Read for hex_conservative::HexToBytesIter<'a>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::error::Error + 'static> core::error::Error for hex_conservative::error::FromHexError<E>
+impl<E: core::error::Error + 'static> core::error::Error for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::error::Error + 'static> core::error::Error for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::ContainsPrefixError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::MissingPrefixError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Send for hex_conservative::error::FromHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Sync for hex_conservative::error::FromHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::error::FromHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -127,10 +214,18 @@ impl<const CAP: usize> core::panic::unwind_safe::UnwindSafe for hex_conservative
 impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
+pub enum hex_conservative::FromHexError<E>
+pub enum hex_conservative::FromNoPrefixHexError<E>
+pub enum hex_conservative::FromPrefixedHexError<E>
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::error::FromHexError<E>
+pub enum hex_conservative::error::FromNoPrefixHexError<E>
+pub enum hex_conservative::error::FromPrefixedHexError<E>
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::parse::FromHexError<E>
+pub enum hex_conservative::parse::FromNoPrefixHexError<E>
+pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -162,8 +257,8 @@ pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
 pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -180,28 +275,17 @@ pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
-pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::error::OddLengthStringError>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -219,30 +303,106 @@ pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> us
 pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::ContainsPrefixError::clone(&self) -> hex_conservative::error::ContainsPrefixError
+pub fn hex_conservative::error::ContainsPrefixError::eq(&self, other: &hex_conservative::error::ContainsPrefixError) -> bool
+pub fn hex_conservative::error::ContainsPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::ContainsPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::FromHexError<E>::clone(&self) -> hex_conservative::error::FromHexError<E>
+pub fn hex_conservative::error::FromHexError<E>::eq(&self, other: &hex_conservative::error::FromHexError<E>) -> bool
+pub fn hex_conservative::error::FromHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromHexError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::clone(&self) -> hex_conservative::error::FromNoPrefixHexError<E>
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::eq(&self, other: &hex_conservative::error::FromNoPrefixHexError<E>) -> bool
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::ContainsPrefixError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::FromPrefixedHexError<E>::clone(&self) -> hex_conservative::error::FromPrefixedHexError<E>
+pub fn hex_conservative::error::FromPrefixedHexError<E>::eq(&self, other: &hex_conservative::error::FromPrefixedHexError<E>) -> bool
+pub fn hex_conservative::error::FromPrefixedHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::MissingPrefixError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::HexToArrayError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidCharError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::InvalidLengthError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::MissingPrefixError::clone(&self) -> hex_conservative::error::MissingPrefixError
+pub fn hex_conservative::error::MissingPrefixError::eq(&self, other: &hex_conservative::error::MissingPrefixError) -> bool
+pub fn hex_conservative::error::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::MissingPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::OddLengthStringError::clone(&self) -> hex_conservative::error::OddLengthStringError
+pub fn hex_conservative::error::OddLengthStringError::eq(&self, other: &hex_conservative::error::OddLengthStringError) -> bool
+pub fn hex_conservative::error::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthStringError::input_string_length(&self) -> usize
+pub fn hex_conservative::error::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::serde::deserialize<'de, D, T>(d: D) -> core::result::Result<T, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>, T: serde::de::Deserialize<'de> + hex_conservative::parse::FromHex
 pub fn hex_conservative::serde::serialize<S, T>(data: T, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
 pub fn hex_conservative::serde::serialize_lower<S, T>(data: T, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
 pub fn hex_conservative::serde::serialize_upper<S, T>(data: T, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::FromHexError::Invalid(E)
+pub hex_conservative::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::FromHexError::Invalid(E)
+pub hex_conservative::error::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::error::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::error::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::error::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::FromHexError::Invalid(E)
+pub hex_conservative::parse::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::parse::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::parse::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::parse::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -250,15 +410,21 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub mod hex_conservative::serde
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::InvalidCharError
 pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthStringError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -294,13 +460,13 @@ pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
 pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
-pub type alloc::vec::Vec<u8>::Error = hex_conservative::HexToBytesError
+pub type [u8; LEN]::Error = hex_conservative::error::HexToArrayError
+pub type alloc::vec::Vec<u8>::Error = hex_conservative::error::InvalidCharError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::Error: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::Error: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::Error: core::fmt::Debug + core::fmt::Display

--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -1,41 +1,54 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::error::Error for hex_conservative::HexToArrayError
 impl core::error::Error for hex_conservative::HexToBytesError
+impl core::error::Error for hex_conservative::OddLengthStringError
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -177,13 +190,18 @@ pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -220,11 +238,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -237,6 +255,7 @@ pub mod hex_conservative::prelude
 pub mod hex_conservative::serde
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -227,35 +227,64 @@ pub enum hex_conservative::parse::FromNoPrefixHexError<E>
 pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1024]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 10]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 11]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 128]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 12]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 13]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 14]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 15]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 16]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2048]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 20]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 256]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 32]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 33]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 3]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4096]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 512]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 5]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 64]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 65]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 6]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 7]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 9]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::as_hex(self) -> Self::Display
+pub fn &'a [u8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
+pub fn &'a alloc::vec::Vec<u8>::as_hex_backwards(self) -> Self::Display
 pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
 pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
@@ -271,6 +300,7 @@ pub fn hex_conservative::Case::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn hex_conservative::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
@@ -293,12 +323,14 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::is_full(&self) -> bool
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::new() -> Self
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_byte(&mut self, byte: u8, case: hex_conservative::Case)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_backwards<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>, <I as core::iter::traits::collect::IntoIterator>::IntoIter: core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_min<'a>(&mut self, bytes: &'a [u8], case: hex_conservative::Case) -> &'a [u8]
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::space_remaining(&self) -> usize
 pub fn hex_conservative::display::DisplayArray<'a, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::display::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
@@ -358,6 +390,7 @@ pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::re
 pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::prelude::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String

--- a/api/alloc.txt
+++ b/api/alloc.txt
@@ -217,35 +217,64 @@ pub enum hex_conservative::parse::FromNoPrefixHexError<E>
 pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1024]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 10]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 11]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 128]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 12]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 13]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 14]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 15]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 16]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2048]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 20]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 256]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 32]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 33]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 3]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4096]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 512]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 5]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 64]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 65]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 6]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 7]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 9]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::as_hex(self) -> Self::Display
+pub fn &'a [u8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
+pub fn &'a alloc::vec::Vec<u8>::as_hex_backwards(self) -> Self::Display
 pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
 pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
@@ -261,6 +290,7 @@ pub fn hex_conservative::Case::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn hex_conservative::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
@@ -282,12 +312,14 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::is_full(&self) -> bool
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::new() -> Self
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_byte(&mut self, byte: u8, case: hex_conservative::Case)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_backwards<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>, <I as core::iter::traits::collect::IntoIterator>::IntoIter: core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_min<'a>(&mut self, bytes: &'a [u8], case: hex_conservative::Case) -> &'a [u8]
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::space_remaining(&self) -> usize
 pub fn hex_conservative::display::DisplayArray<'a, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::display::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
@@ -340,6 +372,7 @@ pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::re
 pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::prelude::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String

--- a/api/alloc.txt
+++ b/api/alloc.txt
@@ -1,51 +1,94 @@
+#[non_exhaustive] pub struct hex_conservative::error::ContainsPrefixError
+#[non_exhaustive] pub struct hex_conservative::error::MissingPrefixError
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::ContainsPrefixError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::MissingPrefixError
+impl core::clone::Clone for hex_conservative::error::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::MissingPrefixError
+impl core::cmp::Eq for hex_conservative::error::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::MissingPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthStringError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::MissingPrefixError
+impl core::fmt::Debug for hex_conservative::error::OddLengthStringError
+impl core::fmt::Display for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::MissingPrefixError
+impl core::fmt::Display for hex_conservative::error::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthStringError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::ContainsPrefixError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::MissingPrefixError
+impl core::marker::Send for hex_conservative::error::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::ContainsPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::MissingPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::ContainsPrefixError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::MissingPrefixError
+impl core::marker::Sync for hex_conservative::error::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::ContainsPrefixError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::MissingPrefixError
+impl core::marker::Unpin for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthStringError
+impl hex_conservative::error::ContainsPrefixError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::MissingPrefixError
+impl hex_conservative::error::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -104,6 +147,44 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
 impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::ContainsPrefixError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::MissingPrefixError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Send for hex_conservative::error::FromHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Sync for hex_conservative::error::FromHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::error::FromHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -123,10 +204,18 @@ impl<const CAP: usize> core::panic::unwind_safe::UnwindSafe for hex_conservative
 impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
+pub enum hex_conservative::FromHexError<E>
+pub enum hex_conservative::FromNoPrefixHexError<E>
+pub enum hex_conservative::FromPrefixedHexError<E>
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::error::FromHexError<E>
+pub enum hex_conservative::error::FromNoPrefixHexError<E>
+pub enum hex_conservative::error::FromPrefixedHexError<E>
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::parse::FromHexError<E>
+pub enum hex_conservative::parse::FromNoPrefixHexError<E>
+pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -158,8 +247,8 @@ pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
 pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -176,24 +265,16 @@ pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::error::OddLengthStringError>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -211,26 +292,95 @@ pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> us
 pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::ContainsPrefixError::clone(&self) -> hex_conservative::error::ContainsPrefixError
+pub fn hex_conservative::error::ContainsPrefixError::eq(&self, other: &hex_conservative::error::ContainsPrefixError) -> bool
+pub fn hex_conservative::error::ContainsPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::ContainsPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::FromHexError<E>::clone(&self) -> hex_conservative::error::FromHexError<E>
+pub fn hex_conservative::error::FromHexError<E>::eq(&self, other: &hex_conservative::error::FromHexError<E>) -> bool
+pub fn hex_conservative::error::FromHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::clone(&self) -> hex_conservative::error::FromNoPrefixHexError<E>
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::eq(&self, other: &hex_conservative::error::FromNoPrefixHexError<E>) -> bool
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::ContainsPrefixError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::clone(&self) -> hex_conservative::error::FromPrefixedHexError<E>
+pub fn hex_conservative::error::FromPrefixedHexError<E>::eq(&self, other: &hex_conservative::error::FromPrefixedHexError<E>) -> bool
+pub fn hex_conservative::error::FromPrefixedHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::MissingPrefixError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::MissingPrefixError::clone(&self) -> hex_conservative::error::MissingPrefixError
+pub fn hex_conservative::error::MissingPrefixError::eq(&self, other: &hex_conservative::error::MissingPrefixError) -> bool
+pub fn hex_conservative::error::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::MissingPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::OddLengthStringError::clone(&self) -> hex_conservative::error::OddLengthStringError
+pub fn hex_conservative::error::OddLengthStringError::eq(&self, other: &hex_conservative::error::OddLengthStringError) -> bool
+pub fn hex_conservative::error::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthStringError::input_string_length(&self) -> usize
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::FromHexError::Invalid(E)
+pub hex_conservative::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::FromHexError::Invalid(E)
+pub hex_conservative::error::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::error::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::error::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::error::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::FromHexError::Invalid(E)
+pub hex_conservative::parse::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::parse::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::parse::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::parse::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -238,14 +388,20 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::InvalidCharError
 pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthStringError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -281,13 +437,13 @@ pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
 pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
-pub type alloc::vec::Vec<u8>::Error = hex_conservative::HexToBytesError
+pub type [u8; LEN]::Error = hex_conservative::error::HexToArrayError
+pub type alloc::vec::Vec<u8>::Error = hex_conservative::error::InvalidCharError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::Error: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::Error: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::Error: core::fmt::Debug + core::fmt::Display

--- a/api/alloc.txt
+++ b/api/alloc.txt
@@ -1,39 +1,51 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -173,11 +185,15 @@ pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesEr
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -210,11 +226,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -226,6 +242,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/core2.txt
+++ b/api/core2.txt
@@ -1,51 +1,94 @@
+#[non_exhaustive] pub struct hex_conservative::error::ContainsPrefixError
+#[non_exhaustive] pub struct hex_conservative::error::MissingPrefixError
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::ContainsPrefixError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::MissingPrefixError
+impl core::clone::Clone for hex_conservative::error::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::MissingPrefixError
+impl core::cmp::Eq for hex_conservative::error::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::MissingPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthStringError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::MissingPrefixError
+impl core::fmt::Debug for hex_conservative::error::OddLengthStringError
+impl core::fmt::Display for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::MissingPrefixError
+impl core::fmt::Display for hex_conservative::error::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthStringError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::ContainsPrefixError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::MissingPrefixError
+impl core::marker::Send for hex_conservative::error::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::ContainsPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::MissingPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::ContainsPrefixError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::MissingPrefixError
+impl core::marker::Sync for hex_conservative::error::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::ContainsPrefixError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::MissingPrefixError
+impl core::marker::Unpin for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthStringError
+impl hex_conservative::error::ContainsPrefixError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::MissingPrefixError
+impl hex_conservative::error::OddLengthStringError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -103,6 +146,44 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::ContainsPrefixError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::MissingPrefixError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Send for hex_conservative::error::FromHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Sync for hex_conservative::error::FromHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::error::FromHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -122,10 +203,18 @@ impl<const CAP: usize> core::panic::unwind_safe::UnwindSafe for hex_conservative
 impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
+pub enum hex_conservative::FromHexError<E>
+pub enum hex_conservative::FromNoPrefixHexError<E>
+pub enum hex_conservative::FromPrefixedHexError<E>
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::error::FromHexError<E>
+pub enum hex_conservative::error::FromNoPrefixHexError<E>
+pub enum hex_conservative::error::FromPrefixedHexError<E>
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::parse::FromHexError<E>
+pub enum hex_conservative::parse::FromNoPrefixHexError<E>
+pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -155,7 +244,7 @@ pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -168,25 +257,17 @@ pub fn hex_conservative::Case::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::error::OddLengthStringError>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> core2::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -200,22 +281,91 @@ pub fn hex_conservative::display::DisplayArray<'a, LEN>::fmt(&self, f: &mut core
 pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::ContainsPrefixError::clone(&self) -> hex_conservative::error::ContainsPrefixError
+pub fn hex_conservative::error::ContainsPrefixError::eq(&self, other: &hex_conservative::error::ContainsPrefixError) -> bool
+pub fn hex_conservative::error::ContainsPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::ContainsPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::FromHexError<E>::clone(&self) -> hex_conservative::error::FromHexError<E>
+pub fn hex_conservative::error::FromHexError<E>::eq(&self, other: &hex_conservative::error::FromHexError<E>) -> bool
+pub fn hex_conservative::error::FromHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::clone(&self) -> hex_conservative::error::FromNoPrefixHexError<E>
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::eq(&self, other: &hex_conservative::error::FromNoPrefixHexError<E>) -> bool
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::ContainsPrefixError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::clone(&self) -> hex_conservative::error::FromPrefixedHexError<E>
+pub fn hex_conservative::error::FromPrefixedHexError<E>::eq(&self, other: &hex_conservative::error::FromPrefixedHexError<E>) -> bool
+pub fn hex_conservative::error::FromPrefixedHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::MissingPrefixError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::MissingPrefixError::clone(&self) -> hex_conservative::error::MissingPrefixError
+pub fn hex_conservative::error::MissingPrefixError::eq(&self, other: &hex_conservative::error::MissingPrefixError) -> bool
+pub fn hex_conservative::error::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::MissingPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::OddLengthStringError::clone(&self) -> hex_conservative::error::OddLengthStringError
+pub fn hex_conservative::error::OddLengthStringError::eq(&self, other: &hex_conservative::error::OddLengthStringError) -> bool
+pub fn hex_conservative::error::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthStringError::input_string_length(&self) -> usize
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::FromHexError::Invalid(E)
+pub hex_conservative::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::FromHexError::Invalid(E)
+pub hex_conservative::error::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::error::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::error::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::error::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::FromHexError::Invalid(E)
+pub hex_conservative::parse::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::parse::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::parse::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::parse::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -223,14 +373,20 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::InvalidCharError
 pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthStringError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -265,12 +421,12 @@ pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
+pub type [u8; LEN]::Error = hex_conservative::error::HexToArrayError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::Error: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::Error: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::Error: core::fmt::Debug + core::fmt::Display

--- a/api/core2.txt
+++ b/api/core2.txt
@@ -1,39 +1,51 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -165,12 +177,16 @@ pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesEr
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> core2::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -195,11 +211,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -211,6 +227,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/core2.txt
+++ b/api/core2.txt
@@ -216,33 +216,61 @@ pub enum hex_conservative::parse::FromNoPrefixHexError<E>
 pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1024]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 10]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 11]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 128]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 12]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 13]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 14]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 15]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 16]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2048]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 20]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 256]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 32]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 33]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 3]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4096]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 512]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 5]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 64]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 65]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 6]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 7]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 9]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::as_hex(self) -> Self::Display
+pub fn &'a [u8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
@@ -256,6 +284,7 @@ pub fn hex_conservative::Case::eq(&self, other: &hex_conservative::Case) -> bool
 pub fn hex_conservative::Case::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
@@ -275,11 +304,13 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::is_full(&self) -> bool
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::new() -> Self
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_byte(&mut self, byte: u8, case: hex_conservative::Case)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_backwards<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>, <I as core::iter::traits::collect::IntoIterator>::IntoIter: core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_min<'a>(&mut self, bytes: &'a [u8], case: hex_conservative::Case) -> &'a [u8]
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::space_remaining(&self) -> usize
 pub fn hex_conservative::display::DisplayArray<'a, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::display::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::error::ContainsPrefixError::clone(&self) -> hex_conservative::error::ContainsPrefixError
 pub fn hex_conservative::error::ContainsPrefixError::eq(&self, other: &hex_conservative::error::ContainsPrefixError) -> bool
@@ -328,6 +359,7 @@ pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex(s: &str) -> cor
 pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
 pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::prelude::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>

--- a/api/default-features.txt
+++ b/api/default-features.txt
@@ -1,41 +1,54 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::error::Error for hex_conservative::HexToArrayError
 impl core::error::Error for hex_conservative::HexToBytesError
+impl core::error::Error for hex_conservative::OddLengthStringError
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -177,13 +190,18 @@ pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -216,11 +234,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -232,6 +250,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/default-features.txt
+++ b/api/default-features.txt
@@ -227,35 +227,64 @@ pub enum hex_conservative::parse::FromNoPrefixHexError<E>
 pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1024]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 10]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 11]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 128]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 12]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 13]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 14]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 15]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 16]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2048]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 20]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 256]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 32]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 33]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 3]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4096]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 512]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 5]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 64]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 65]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 6]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 7]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 9]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::as_hex(self) -> Self::Display
+pub fn &'a [u8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
+pub fn &'a alloc::vec::Vec<u8>::as_hex_backwards(self) -> Self::Display
 pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
 pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
@@ -271,6 +300,7 @@ pub fn hex_conservative::Case::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn hex_conservative::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
@@ -293,12 +323,14 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::is_full(&self) -> bool
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::new() -> Self
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_byte(&mut self, byte: u8, case: hex_conservative::Case)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_backwards<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>, <I as core::iter::traits::collect::IntoIterator>::IntoIter: core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_min<'a>(&mut self, bytes: &'a [u8], case: hex_conservative::Case) -> &'a [u8]
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::space_remaining(&self) -> usize
 pub fn hex_conservative::display::DisplayArray<'a, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::display::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
@@ -358,6 +390,7 @@ pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::re
 pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::prelude::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String

--- a/api/default-features.txt
+++ b/api/default-features.txt
@@ -1,54 +1,100 @@
+#[non_exhaustive] pub struct hex_conservative::error::ContainsPrefixError
+#[non_exhaustive] pub struct hex_conservative::error::MissingPrefixError
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::ContainsPrefixError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::MissingPrefixError
+impl core::clone::Clone for hex_conservative::error::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::MissingPrefixError
+impl core::cmp::Eq for hex_conservative::error::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::MissingPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthStringError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
 impl core::default::Default for hex_conservative::Case
-impl core::error::Error for hex_conservative::HexToArrayError
-impl core::error::Error for hex_conservative::HexToBytesError
-impl core::error::Error for hex_conservative::OddLengthStringError
+impl core::error::Error for hex_conservative::error::ContainsPrefixError
+impl core::error::Error for hex_conservative::error::HexToArrayError
+impl core::error::Error for hex_conservative::error::InvalidCharError
+impl core::error::Error for hex_conservative::error::InvalidLengthError
+impl core::error::Error for hex_conservative::error::MissingPrefixError
+impl core::error::Error for hex_conservative::error::OddLengthStringError
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::MissingPrefixError
+impl core::fmt::Debug for hex_conservative::error::OddLengthStringError
+impl core::fmt::Display for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::MissingPrefixError
+impl core::fmt::Display for hex_conservative::error::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthStringError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::ContainsPrefixError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::MissingPrefixError
+impl core::marker::Send for hex_conservative::error::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::ContainsPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::MissingPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::ContainsPrefixError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::MissingPrefixError
+impl core::marker::Sync for hex_conservative::error::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::ContainsPrefixError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::MissingPrefixError
+impl core::marker::Unpin for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthStringError
+impl hex_conservative::error::ContainsPrefixError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::MissingPrefixError
+impl hex_conservative::error::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -108,6 +154,47 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
 impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
 impl<'a> std::io::Read for hex_conservative::HexToBytesIter<'a>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::error::Error + 'static> core::error::Error for hex_conservative::error::FromHexError<E>
+impl<E: core::error::Error + 'static> core::error::Error for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::error::Error + 'static> core::error::Error for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::ContainsPrefixError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::MissingPrefixError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Send for hex_conservative::error::FromHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Sync for hex_conservative::error::FromHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::error::FromHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -127,10 +214,18 @@ impl<const CAP: usize> core::panic::unwind_safe::UnwindSafe for hex_conservative
 impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
+pub enum hex_conservative::FromHexError<E>
+pub enum hex_conservative::FromNoPrefixHexError<E>
+pub enum hex_conservative::FromPrefixedHexError<E>
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::error::FromHexError<E>
+pub enum hex_conservative::error::FromNoPrefixHexError<E>
+pub enum hex_conservative::error::FromPrefixedHexError<E>
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::parse::FromHexError<E>
+pub enum hex_conservative::parse::FromNoPrefixHexError<E>
+pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -162,8 +257,8 @@ pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
 pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -180,28 +275,17 @@ pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
-pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::error::OddLengthStringError>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -219,26 +303,102 @@ pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> us
 pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::ContainsPrefixError::clone(&self) -> hex_conservative::error::ContainsPrefixError
+pub fn hex_conservative::error::ContainsPrefixError::eq(&self, other: &hex_conservative::error::ContainsPrefixError) -> bool
+pub fn hex_conservative::error::ContainsPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::ContainsPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::FromHexError<E>::clone(&self) -> hex_conservative::error::FromHexError<E>
+pub fn hex_conservative::error::FromHexError<E>::eq(&self, other: &hex_conservative::error::FromHexError<E>) -> bool
+pub fn hex_conservative::error::FromHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromHexError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::clone(&self) -> hex_conservative::error::FromNoPrefixHexError<E>
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::eq(&self, other: &hex_conservative::error::FromNoPrefixHexError<E>) -> bool
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::ContainsPrefixError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::FromPrefixedHexError<E>::clone(&self) -> hex_conservative::error::FromPrefixedHexError<E>
+pub fn hex_conservative::error::FromPrefixedHexError<E>::eq(&self, other: &hex_conservative::error::FromPrefixedHexError<E>) -> bool
+pub fn hex_conservative::error::FromPrefixedHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::MissingPrefixError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::HexToArrayError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidCharError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::InvalidLengthError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::MissingPrefixError::clone(&self) -> hex_conservative::error::MissingPrefixError
+pub fn hex_conservative::error::MissingPrefixError::eq(&self, other: &hex_conservative::error::MissingPrefixError) -> bool
+pub fn hex_conservative::error::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::MissingPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::OddLengthStringError::clone(&self) -> hex_conservative::error::OddLengthStringError
+pub fn hex_conservative::error::OddLengthStringError::eq(&self, other: &hex_conservative::error::OddLengthStringError) -> bool
+pub fn hex_conservative::error::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthStringError::input_string_length(&self) -> usize
+pub fn hex_conservative::error::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::FromHexError::Invalid(E)
+pub hex_conservative::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::FromHexError::Invalid(E)
+pub hex_conservative::error::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::error::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::error::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::error::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::FromHexError::Invalid(E)
+pub hex_conservative::parse::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::parse::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::parse::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::parse::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -246,14 +406,20 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::InvalidCharError
 pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthStringError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -289,13 +455,13 @@ pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
 pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
-pub type alloc::vec::Vec<u8>::Error = hex_conservative::HexToBytesError
+pub type [u8; LEN]::Error = hex_conservative::error::HexToArrayError
+pub type alloc::vec::Vec<u8>::Error = hex_conservative::error::InvalidCharError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::Error: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::Error: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::Error: core::fmt::Debug + core::fmt::Display

--- a/api/no-default-features.txt
+++ b/api/no-default-features.txt
@@ -215,33 +215,61 @@ pub enum hex_conservative::parse::FromNoPrefixHexError<E>
 pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1024]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 10]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 11]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 128]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 12]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 13]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 14]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 15]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 16]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 1]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2048]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 20]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 256]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 2]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 32]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 33]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 3]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4096]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 4]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 512]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 5]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 64]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 65]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 6]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 7]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
+pub fn &'a [u8; 9]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::as_hex(self) -> Self::Display
+pub fn &'a [u8]::as_hex_backwards(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
@@ -255,6 +283,7 @@ pub fn hex_conservative::Case::eq(&self, other: &hex_conservative::Case) -> bool
 pub fn hex_conservative::Case::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
@@ -273,11 +302,13 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::is_full(&self) -> bool
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::new() -> Self
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_byte(&mut self, byte: u8, case: hex_conservative::Case)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_backwards<I>(&mut self, bytes: I, case: hex_conservative::Case) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>, <I as core::iter::traits::collect::IntoIterator>::IntoIter: core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_min<'a>(&mut self, bytes: &'a [u8], case: hex_conservative::Case) -> &'a [u8]
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::space_remaining(&self) -> usize
 pub fn hex_conservative::display::DisplayArray<'a, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::display::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::error::ContainsPrefixError::clone(&self) -> hex_conservative::error::ContainsPrefixError
 pub fn hex_conservative::error::ContainsPrefixError::eq(&self, other: &hex_conservative::error::ContainsPrefixError) -> bool
@@ -326,6 +357,7 @@ pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex(s: &str) -> cor
 pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
 pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
+pub fn hex_conservative::prelude::DisplayHex::as_hex_backwards(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>

--- a/api/no-default-features.txt
+++ b/api/no-default-features.txt
@@ -1,39 +1,51 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -164,11 +176,15 @@ pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesEr
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -193,11 +209,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -209,6 +225,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/no-default-features.txt
+++ b/api/no-default-features.txt
@@ -1,51 +1,94 @@
+#[non_exhaustive] pub struct hex_conservative::error::ContainsPrefixError
+#[non_exhaustive] pub struct hex_conservative::error::MissingPrefixError
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::ContainsPrefixError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::MissingPrefixError
+impl core::clone::Clone for hex_conservative::error::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::MissingPrefixError
+impl core::cmp::Eq for hex_conservative::error::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::ContainsPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::MissingPrefixError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthStringError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::MissingPrefixError
+impl core::fmt::Debug for hex_conservative::error::OddLengthStringError
+impl core::fmt::Display for hex_conservative::error::ContainsPrefixError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::MissingPrefixError
+impl core::fmt::Display for hex_conservative::error::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthStringError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::ContainsPrefixError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::MissingPrefixError
+impl core::marker::Send for hex_conservative::error::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::ContainsPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::MissingPrefixError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::ContainsPrefixError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::MissingPrefixError
+impl core::marker::Sync for hex_conservative::error::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::ContainsPrefixError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::MissingPrefixError
+impl core::marker::Unpin for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::ContainsPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::MissingPrefixError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthStringError
+impl hex_conservative::error::ContainsPrefixError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::MissingPrefixError
+impl hex_conservative::error::OddLengthStringError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -102,6 +145,44 @@ impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
 impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::clone::Clone> core::clone::Clone for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::Eq> core::cmp::Eq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::cmp::PartialEq> core::cmp::PartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Debug> core::fmt::Debug for hex_conservative::error::FromPrefixedHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E: core::fmt::Display> core::fmt::Display for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::ContainsPrefixError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::MissingPrefixError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::convert::From<hex_conservative::error::OddLengthStringError> for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Send for hex_conservative::error::FromHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Send
+impl<E> core::marker::Send for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Send
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromNoPrefixHexError<E>
+impl<E> core::marker::StructuralPartialEq for hex_conservative::error::FromPrefixedHexError<E>
+impl<E> core::marker::Sync for hex_conservative::error::FromHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Sync for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Sync
+impl<E> core::marker::Unpin for hex_conservative::error::FromHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromNoPrefixHexError<E> where E: core::marker::Unpin
+impl<E> core::marker::Unpin for hex_conservative::error::FromPrefixedHexError<E> where E: core::marker::Unpin
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromNoPrefixHexError<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for hex_conservative::error::FromPrefixedHexError<E> where E: core::panic::unwind_safe::UnwindSafe
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::iterator::Iterator<Item = u8>
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator<Item = u8>
@@ -121,10 +202,18 @@ impl<const CAP: usize> core::panic::unwind_safe::UnwindSafe for hex_conservative
 impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
+pub enum hex_conservative::FromHexError<E>
+pub enum hex_conservative::FromNoPrefixHexError<E>
+pub enum hex_conservative::FromPrefixedHexError<E>
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::error::FromHexError<E>
+pub enum hex_conservative::error::FromNoPrefixHexError<E>
+pub enum hex_conservative::error::FromPrefixedHexError<E>
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::parse::FromHexError<E>
+pub enum hex_conservative::parse::FromNoPrefixHexError<E>
+pub enum hex_conservative::parse::FromPrefixedHexError<E>
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -154,7 +243,7 @@ pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -167,24 +256,16 @@ pub fn hex_conservative::Case::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::error::OddLengthStringError>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -198,22 +279,91 @@ pub fn hex_conservative::display::DisplayArray<'a, LEN>::fmt(&self, f: &mut core
 pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::ContainsPrefixError::clone(&self) -> hex_conservative::error::ContainsPrefixError
+pub fn hex_conservative::error::ContainsPrefixError::eq(&self, other: &hex_conservative::error::ContainsPrefixError) -> bool
+pub fn hex_conservative::error::ContainsPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::ContainsPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::FromHexError<E>::clone(&self) -> hex_conservative::error::FromHexError<E>
+pub fn hex_conservative::error::FromHexError<E>::eq(&self, other: &hex_conservative::error::FromHexError<E>) -> bool
+pub fn hex_conservative::error::FromHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::clone(&self) -> hex_conservative::error::FromNoPrefixHexError<E>
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::eq(&self, other: &hex_conservative::error::FromNoPrefixHexError<E>) -> bool
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::ContainsPrefixError) -> Self
+pub fn hex_conservative::error::FromNoPrefixHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::clone(&self) -> hex_conservative::error::FromPrefixedHexError<E>
+pub fn hex_conservative::error::FromPrefixedHexError<E>::eq(&self, other: &hex_conservative::error::FromPrefixedHexError<E>) -> bool
+pub fn hex_conservative::error::FromPrefixedHexError<E>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::MissingPrefixError) -> Self
+pub fn hex_conservative::error::FromPrefixedHexError<E>::from(e: hex_conservative::error::OddLengthStringError) -> Self
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::MissingPrefixError::clone(&self) -> hex_conservative::error::MissingPrefixError
+pub fn hex_conservative::error::MissingPrefixError::eq(&self, other: &hex_conservative::error::MissingPrefixError) -> bool
+pub fn hex_conservative::error::MissingPrefixError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::MissingPrefixError::new(input: &str) -> Self
+pub fn hex_conservative::error::OddLengthStringError::clone(&self) -> hex_conservative::error::OddLengthStringError
+pub fn hex_conservative::error::OddLengthStringError::eq(&self, other: &hex_conservative::error::OddLengthStringError) -> bool
+pub fn hex_conservative::error::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthStringError::input_string_length(&self) -> usize
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::parse::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_maybe_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_no_prefix_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromNoPrefixHexError<Self::Error>>
+pub fn hex_conservative::prelude::FromHex::from_prefixed_hex(s: &str) -> core::result::Result<Self, hex_conservative::error::FromPrefixedHexError<Self::Error>>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::FromHexError::Invalid(E)
+pub hex_conservative::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::FromHexError::Invalid(E)
+pub hex_conservative::error::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::error::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::error::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::error::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::error::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::FromHexError::Invalid(E)
+pub hex_conservative::parse::FromHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Invalid(E)
+pub hex_conservative::parse::FromNoPrefixHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromNoPrefixHexError::Prefix(hex_conservative::error::ContainsPrefixError)
+pub hex_conservative::parse::FromPrefixedHexError::Invalid(E)
+pub hex_conservative::parse::FromPrefixedHexError::OddLengthString(hex_conservative::error::OddLengthStringError)
+pub hex_conservative::parse::FromPrefixedHexError::Prefix(hex_conservative::error::MissingPrefixError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -221,14 +371,20 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::InvalidCharError
 pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthStringError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -263,12 +419,12 @@ pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
+pub type [u8; LEN]::Error = hex_conservative::error::HexToArrayError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::Error: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::Error: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::Error: core::fmt::Debug + core::fmt::Display

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -1,4 +1,5 @@
-//! Demonstrate hexadecimal encoding and decoding for a type where hex is not the natural hex representation but the type can still be encoded/decoded to/from hex.
+//! Demonstrate hexadecimal encoding and decoding for a type where hex is not the natural hex
+//! representation but the type can still be encoded/decoded to/from hex.
 //!
 //! For a type where hex is the natural representation see `./hexy.rs`.
 //! To wrap an array see the `./wrap_array_*` examples.
@@ -6,7 +7,7 @@
 use core::fmt;
 use core::str::FromStr;
 
-use hex_conservative::{DisplayHex, FromHex, HexToArrayError, HexToBytesError};
+use hex_conservative::{DisplayHex, FromHex, HexToArrayError, InvalidCharError};
 
 fn main() {
     let s = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
@@ -55,7 +56,7 @@ impl fmt::Display for ALittleBitHexy {
 }
 
 impl FromStr for ALittleBitHexy {
-    type Err = Error;
+    type Err = FromStrError;
     fn from_str(_: &str) -> Result<Self, Self::Err> {
         todo!("Parse a string as formatted by `Display`")
     }
@@ -64,14 +65,20 @@ impl FromStr for ALittleBitHexy {
 // If the object can be parsed from hex, implement `FromHex`.
 
 impl FromHex for ALittleBitHexy {
-    type Error = HexToArrayError;
+    type Error = CustomError;
 
     fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
     where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, InvalidCharError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         // Errors if the iterator is the wrong length.
-        let data = <[u8; 32] as FromHex>::from_byte_iter(iter)?;
+        let data = <[u8; 32] as FromHex>::from_byte_iter(iter).map_err(CustomError::Hex)?;
+
+        // An example of some application specific error.
+        if data == [0; 32] {
+            return Err(CustomError::AllZeros);
+        }
+
         // This is a contrived example (using x==0).
         Ok(ALittleBitHexy { data, x: 0 })
     }
@@ -116,46 +123,29 @@ impl<'a> fmt::UpperHex for DisplayALittleBitHexy<'a> {
     }
 }
 
-/// Example Error.
+/// Example error returned by `FromStr`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Error {
-    /// Conversion error while parsing hex string.
-    Conversion(HexToBytesError),
-    /// Invalid string for array.
-    Array(HexToArrayError),
-    /// Attempt to parse invalid string.
-    InvalidStringFormat,
-}
+pub struct FromStrError {}
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Error::*;
-
-        match *self {
-            Conversion(ref e) => write!(f, "conversion error: {:?}", e),
-            Array(ref e) => write!(f, "array error: {:?}", e),
-            InvalidStringFormat => write!(f, "invalid string format"),
-        }
-    }
+impl fmt::Display for FromStrError {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result { todo!() }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use Error::*;
+impl std::error::Error for FromStrError {}
 
-        match *self {
-            Conversion(ref e) => Some(e),
-            Array(ref e) => Some(e),
-            InvalidStringFormat => None,
-        }
-    }
+/// Example error used by `FromHex` implementation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CustomError {
+    /// Invalid hex to bytes conversion.
+    Hex(HexToArrayError),
+    /// Some other application/type specific error case.
+    AllZeros,
 }
 
-impl From<HexToBytesError> for Error {
-    fn from(e: HexToBytesError) -> Self { Self::Conversion(e) }
+impl fmt::Display for CustomError {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result { todo!() }
 }
 
-impl From<HexToArrayError> for Error {
-    fn from(e: HexToArrayError) -> Self { Self::Array(e) }
-}
+#[cfg(feature = "std")]
+impl std::error::Error for CustomError {}

--- a/examples/wrap_array_display_hex_trait.rs
+++ b/examples/wrap_array_display_hex_trait.rs
@@ -5,7 +5,7 @@
 //! For an example using the standard library `fmt` traits see `./wrap_array_fmt_traits.rs`.
 
 use hex_conservative::display::DisplayArray;
-use hex_conservative::{DisplayHex, FromHex, HexToArrayError, HexToBytesError};
+use hex_conservative::{DisplayHex, FromHex, HexToArrayError, InvalidCharError};
 
 fn main() {
     let hex = "00000000cafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
@@ -18,8 +18,9 @@ fn main() {
     println!("LowerHex: {:x}", array.as_hex());
     println!("UpperHex: {:X}", array.as_hex());
     println!("Display: {}", array.as_hex());
+    println!("Alternate: {:#}", wrap.as_hex());
     println!("Debug: {:?}", array.as_hex());
-    println!("Debug pretty: {:#?}", array.as_hex());
+    println!("Alternate: {:#?}", array.as_hex());
 
     println!("\n");
 
@@ -29,8 +30,9 @@ fn main() {
     println!("LowerHex: {:x}", wrap.as_hex());
     println!("UpperHex: {:X}", wrap.as_hex());
     println!("Display: {}", wrap.as_hex());
+    println!("Alternate: {:#}", wrap.as_hex());
     println!("Debug: {:?}", wrap.as_hex());
-    println!("Debug pretty: {:#?}", wrap.as_hex());
+    println!("Alternate: {:#?}", wrap.as_hex());
 
     #[cfg(feature = "alloc")]
     {
@@ -49,7 +51,7 @@ impl FromHex for Wrap {
 
     fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
     where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, InvalidCharError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         Ok(Self(FromHex::from_byte_iter(iter)?))
     }

--- a/examples/wrap_array_fmt_traits.rs
+++ b/examples/wrap_array_fmt_traits.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Hex encode/decode a type that wraps an array - using implementations of the standard library
+//! Hex encode/decode a type that wraps an array - using implementations of the standard library `fmt` traits.
 //!
-//! `fmt` traits. For an example using the `DisplayHex` trait see `./wrap_array_display_hex.rs`.
+//! For an example using the `DisplayHex` trait see `./wrap_array_display_hex.rs`.
 
 use core::fmt;
 use core::str::FromStr;
 
-use hex_conservative::{DisplayHex, FromHex, HexToArrayError};
+use hex_conservative::{DisplayHex, FromHex, FromHexError, HexToArrayError};
 
 fn main() {
     let hex = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
@@ -20,8 +20,9 @@ fn main() {
     println!("LowerHex: {:x}", array.as_hex());
     println!("UpperHex: {:X}", array.as_hex());
     println!("Display: {}", array.as_hex());
+    println!("Alternate: {:#}", array.as_hex());
     println!("Debug: {:?}", array.as_hex());
-    println!("Debug pretty: {:#?}", array.as_hex());
+    println!("Alternate: {:#?}", array.as_hex());
 
     println!("\n");
 
@@ -31,8 +32,9 @@ fn main() {
     println!("LowerHex: {:x}", wrap);
     println!("UpperHex: {:X}", wrap);
     println!("Display: {}", wrap);
+    println!("Alternate: {:#}", wrap);
     println!("Debug: {:?}", wrap);
-    println!("Debug pretty: {:#?}", wrap);
+    println!("Alternate: {:#?}", wrap);
 
     // We cannot call `to_lower_hex_string` on the wrapped type to allocate a string, if you wish to
     // use that trait method see `./wrap_array_display_hex_trait.rs`.
@@ -68,6 +70,6 @@ impl fmt::UpperHex for Wrap {
 }
 
 impl FromStr for Wrap {
-    type Err = HexToArrayError;
+    type Err = FromHexError<HexToArrayError>;
     fn from_str(s: &str) -> Result<Self, Self::Err> { Ok(Self(FromHex::from_hex(s)?)) }
 }

--- a/fuzz/fuzz_targets/hex.rs
+++ b/fuzz/fuzz_targets/hex.rs
@@ -1,14 +1,16 @@
+//! This is based on `examples::hexy`.
+
 use std::fmt;
 use std::str::FromStr;
 
-use hex::{fmt_hex_exact, Case, FromHex, HexToArrayError, HexToBytesError};
+use hex::{fmt_hex_exact, Case, FromHex, FromHexError, HexToArrayError, InvalidCharError};
 use honggfuzz::fuzz;
 
 const LEN: usize = 32; // Arbitrary amount of data.
 
 /// A struct that always uses hex when in string form.
 pub struct Hexy {
-    // Some opaque data.
+    // Some opaque data, this exampled is explicitly meant to be more than just wrapping an array
     data: [u8; LEN],
 }
 
@@ -22,7 +24,7 @@ impl fmt::Display for Hexy {
 }
 
 impl FromStr for Hexy {
-    type Err = HexToArrayError;
+    type Err = FromHexError<HexToArrayError>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> { Hexy::from_hex(s) }
 }
@@ -44,7 +46,7 @@ impl FromHex for Hexy {
 
     fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
     where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, InvalidCharError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         // Errors if the iterator is the wrong length.
         let a = <[u8; 32] as FromHex>::from_byte_iter(iter)?;

--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -56,6 +56,22 @@ impl<const CAP: usize> BufEncoder<CAP> {
         self.put_bytes_inner(bytes.into_iter(), case)
     }
 
+    /// Encodes `bytes` backwards as hex in given `case` and appends them to the buffer.
+    ///
+    /// ## Panics
+    ///
+    /// The method panics if the bytes wouldn't fit the buffer.
+    #[inline]
+    #[track_caller]
+    pub fn put_bytes_backwards<I>(&mut self, bytes: I, case: Case)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<u8>,
+        I::IntoIter: DoubleEndedIterator,
+    {
+        self.put_bytes_inner(bytes.into_iter().rev(), case)
+    }
+
     #[inline]
     #[track_caller]
     fn put_bytes_inner<I>(&mut self, bytes: I, case: Case)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 
+//! Error types for the hex crate.
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::string::{String, ToString};
 use core::fmt;
 
 use crate::write_err;
@@ -28,19 +32,19 @@ macro_rules! write_err {
 
 /// Hex decoding error.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum HexToBytesError {
-    /// Non-hexadecimal character.
-    InvalidChar(InvalidCharError),
+pub enum FromHexError<E> {
+    /// Failed to create object from bytes iterator.
+    Invalid(E),
     /// Purported hex string had odd length.
     OddLengthString(OddLengthStringError),
 }
 
-impl fmt::Display for HexToBytesError {
+impl<E: fmt::Display> fmt::Display for FromHexError<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use HexToBytesError::*;
+        use FromHexError::*;
 
         match *self {
-            InvalidChar(ref e) => write_err!(f, "invalid char, failed to create bytes from hex"; e),
+            Invalid(ref e) => write_err!(f, "invalid"; e),
             OddLengthString(ref e) =>
                 write_err!(f, "odd length, failed to create bytes from hex"; e),
         }
@@ -48,48 +52,125 @@ impl fmt::Display for HexToBytesError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for HexToBytesError {
+impl<E: std::error::Error + 'static> std::error::Error for FromHexError<E> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use HexToBytesError::*;
+        use FromHexError::*;
 
         match *self {
-            InvalidChar(ref e) => Some(e),
+            Invalid(ref e) => Some(e),
             OddLengthString(ref e) => Some(e),
         }
     }
 }
 
-impl From<InvalidCharError> for HexToBytesError {
-    #[inline]
-    fn from(e: InvalidCharError) -> Self { Self::InvalidChar(e) }
-}
-
-impl From<OddLengthStringError> for HexToBytesError {
+impl<E> From<OddLengthStringError> for FromHexError<E> {
     #[inline]
     fn from(e: OddLengthStringError) -> Self { Self::OddLengthString(e) }
 }
 
-/// Invalid hex character.
+/// Error decoding a hex string that explicitly excludes a prefix.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InvalidCharError {
-    pub(crate) invalid: u8,
+pub enum FromNoPrefixHexError<E> {
+    /// Input string contains a prefix.
+    Prefix(ContainsPrefixError),
+    /// Failed to create object from bytes iterator.
+    Invalid(E),
+    /// Purported hex string had odd length.
+    OddLengthString(OddLengthStringError),
 }
 
-impl fmt::Display for InvalidCharError {
+impl<E: fmt::Display> fmt::Display for FromNoPrefixHexError<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "invalid hex char {}", self.invalid)
+        use FromNoPrefixHexError::*;
+
+        match *self {
+            Prefix(ref e) => write_err!(f, "prefix"; e),
+            Invalid(ref e) => write_err!(f, "invalid"; e),
+            OddLengthString(ref e) =>
+                write_err!(f, "odd length, failed to create bytes from hex"; e),
+        }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for InvalidCharError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+impl<E: std::error::Error + 'static> std::error::Error for FromNoPrefixHexError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use FromNoPrefixHexError::*;
+
+        match *self {
+            Prefix(ref e) => Some(e),
+            Invalid(ref e) => Some(e),
+            OddLengthString(ref e) => Some(e),
+        }
+    }
+}
+
+impl<E> From<ContainsPrefixError> for FromNoPrefixHexError<E> {
+    #[inline]
+    fn from(e: ContainsPrefixError) -> Self { Self::Prefix(e) }
+}
+
+impl<E> From<OddLengthStringError> for FromNoPrefixHexError<E> {
+    #[inline]
+    fn from(e: OddLengthStringError) -> Self { Self::OddLengthString(e) }
+}
+
+/// Error decoding a hex string that explicitly includes a prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FromPrefixedHexError<E> {
+    /// Input string is missing a prefix.
+    Prefix(MissingPrefixError),
+    /// Failed to create object from bytes iterator.
+    Invalid(E),
+    /// Purported hex string had odd length.
+    OddLengthString(OddLengthStringError),
+}
+
+impl<E: fmt::Display> fmt::Display for FromPrefixedHexError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use FromPrefixedHexError::*;
+
+        match *self {
+            Prefix(ref e) => write_err!(f, "prefix"; e),
+            Invalid(ref e) => write_err!(f, "invalid"; e),
+            OddLengthString(ref e) =>
+                write_err!(f, "odd length, failed to create bytes from hex"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E: std::error::Error + 'static> std::error::Error for FromPrefixedHexError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use FromPrefixedHexError::*;
+
+        match *self {
+            Prefix(ref e) => Some(e),
+            Invalid(ref e) => Some(e),
+            OddLengthString(ref e) => Some(e),
+        }
+    }
+}
+
+impl<E> From<MissingPrefixError> for FromPrefixedHexError<E> {
+    #[inline]
+    fn from(e: MissingPrefixError) -> Self { Self::Prefix(e) }
+}
+
+impl<E> From<OddLengthStringError> for FromPrefixedHexError<E> {
+    #[inline]
+    fn from(e: OddLengthStringError) -> Self { Self::OddLengthString(e) }
 }
 
 /// Purported hex string had odd length.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct OddLengthStringError {
     pub(crate) len: usize,
+}
+
+impl OddLengthStringError {
+    /// Returns the length of the input string that caused this error.
+    pub fn input_string_length(&self) -> usize { self.len }
 }
 
 impl fmt::Display for OddLengthStringError {
@@ -103,12 +184,104 @@ impl std::error::Error for OddLengthStringError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
 }
 
+/// Input string contains a prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ContainsPrefixError {
+    #[cfg(feature = "alloc")]
+    input: String,
+}
+
+impl ContainsPrefixError {
+    /// Creates the error using `input` string if we have an allocater.
+    #[allow(unused_variables)] // If alloc feature is not enabled.
+    pub fn new(input: &str) -> Self {
+        #[cfg(feature = "alloc")]
+        let result = Self { input: input.to_string() };
+        #[cfg(not(feature = "alloc"))]
+        let result = Self {};
+
+        result
+    }
+}
+
+impl fmt::Display for ContainsPrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[cfg(feature = "alloc")]
+        let result = write!(f, "input string contained a prefix (e.g. 0x): {}", self.input);
+        #[cfg(not(feature = "alloc"))]
+        let result = write!(f, "input string contained a prefix (e.g. 0x)");
+
+        result
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ContainsPrefixError {}
+
+/// Input string is missing a prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MissingPrefixError {
+    #[cfg(feature = "alloc")]
+    input: String,
+}
+
+impl MissingPrefixError {
+    /// Creates the error using `input` string if we have an allocater.
+    #[allow(unused_variables)] // If alloc feature is not enabled.
+    pub fn new(input: &str) -> Self {
+        #[cfg(feature = "alloc")]
+        let result = Self { input: input.to_string() };
+        #[cfg(not(feature = "alloc"))]
+        let result = Self {};
+
+        result
+    }
+}
+
+impl fmt::Display for MissingPrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[cfg(feature = "alloc")]
+        let result = write!(f, "input string is missing a prefix (e.g. 0x): {}", self.input);
+        #[cfg(not(feature = "alloc"))]
+        let result = write!(f, "input string is missing a prefix (e.g. 0x)");
+
+        result
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MissingPrefixError {}
+
+/// Invalid hex character.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct InvalidCharError {
+    pub(crate) invalid: u8,
+}
+
+impl InvalidCharError {
+    /// Returns the invalid character.
+    pub fn invalid_char(&self) -> u8 { self.invalid }
+}
+
+impl fmt::Display for InvalidCharError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid hex char {}", self.invalid)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidCharError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
 /// Hex decoding error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HexToArrayError {
-    /// Conversion error while parsing hex string.
-    Conversion(HexToBytesError),
-    /// Tried to parse fixed-length hash from a string with the wrong length (got, want).
+    /// Invalid character while parsing hex string.
+    InvalidChar(InvalidCharError),
+    /// Tried to parse fixed-length hash from a string with the wrong length.
     InvalidLength(InvalidLengthError),
 }
 
@@ -117,8 +290,8 @@ impl fmt::Display for HexToArrayError {
         use HexToArrayError::*;
 
         match *self {
-            Conversion(ref e) =>
-                crate::write_err!(f, "conversion error, failed to create array from hex"; e),
+            InvalidChar(ref e) =>
+                crate::write_err!(f, "invalid char, failed to create array from hex"; e),
             InvalidLength(ref e) =>
                 write_err!(f, "invalid length, failed to create array from hex"; e),
         }
@@ -131,15 +304,15 @@ impl std::error::Error for HexToArrayError {
         use HexToArrayError::*;
 
         match *self {
-            Conversion(ref e) => Some(e),
+            InvalidChar(ref e) => Some(e),
             InvalidLength(ref e) => Some(e),
         }
     }
 }
 
-impl From<HexToBytesError> for HexToArrayError {
+impl From<InvalidCharError> for HexToArrayError {
     #[inline]
-    fn from(e: HexToBytesError) -> Self { Self::Conversion(e) }
+    fn from(e: InvalidCharError) -> Self { Self::InvalidChar(e) }
 }
 
 impl From<InvalidLengthError> for HexToArrayError {
@@ -148,10 +321,21 @@ impl From<InvalidLengthError> for HexToArrayError {
 }
 
 /// Tried to parse fixed-length hash from a string with the wrong length.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct InvalidLengthError {
     pub(crate) expected: usize,
     pub(crate) got: usize,
+}
+
+impl InvalidLengthError {
+    /// Creates a new `InvalidLengthError`.
+    pub fn new(got: usize, expected: usize) -> Self { Self { expected, got } }
+
+    /// Returns the expected length of the hex string.
+    pub fn expected_length(&self) -> usize { self.expected }
+
+    /// Returns the invalid length of the parsed hex string.
+    pub fn invalid_length(&self) -> usize { self.got }
 }
 
 impl fmt::Display for InvalidLengthError {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -10,10 +10,10 @@ use std::io;
 #[cfg(all(feature = "core2", not(feature = "std")))]
 use core2::io;
 
-use crate::error::{InvalidCharError, OddLengthStringError};
+use crate::error::InvalidCharError;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::HexToBytesError;
+pub use crate::error::{HexToBytesError, OddLengthStringError};
 
 /// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
 pub struct HexToBytesIter<'a> {
@@ -34,9 +34,9 @@ impl<'a> HexToBytesIter<'a> {
     ///
     /// If the input string is of odd length.
     #[inline]
-    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, HexToBytesError> {
+    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, OddLengthStringError> {
         if s.len() % 2 != 0 {
-            Err(OddLengthStringError { len: s.len() }.into())
+            Err(OddLengthStringError { len: s.len() })
         } else {
             Ok(HexToBytesIter { iter: s.bytes() })
         }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,7 +13,7 @@ use core2::io;
 use crate::error::InvalidCharError;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::{HexToBytesError, OddLengthStringError};
+pub use crate::error::OddLengthStringError;
 
 /// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
 pub struct HexToBytesIter<'a> {
@@ -44,10 +44,10 @@ impl<'a> HexToBytesIter<'a> {
 }
 
 impl<'a> Iterator for HexToBytesIter<'a> {
-    type Item = Result<u8, HexToBytesError>;
+    type Item = Result<u8, InvalidCharError>;
 
     #[inline]
-    fn next(&mut self) -> Option<Result<u8, HexToBytesError>> {
+    fn next(&mut self) -> Option<Result<u8, InvalidCharError>> {
         let hi = self.iter.next()?;
         let lo = self.iter.next().expect("iter length invariant violated, this is a bug");
         Some(hex_chars_to_byte(hi, lo))
@@ -62,7 +62,7 @@ impl<'a> Iterator for HexToBytesIter<'a> {
 
 impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
     #[inline]
-    fn next_back(&mut self) -> Option<Result<u8, HexToBytesError>> {
+    fn next_back(&mut self) -> Option<Result<u8, InvalidCharError>> {
         let lo = self.iter.next_back()?;
         let hi = self.iter.next_back().expect("iter length invariant violated, this is a bug");
         Some(hex_chars_to_byte(hi, lo))
@@ -95,7 +95,7 @@ impl<'a> io::Read for HexToBytesIter<'a> {
 }
 
 /// `hi` and `lo` are bytes representing hex characters.
-fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
+fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, InvalidCharError> {
     let hih = (hi as char).to_digit(16).ok_or(InvalidCharError { invalid: hi })?;
     let loh = (lo as char).to_digit(16).ok_or(InvalidCharError { invalid: lo })?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) use table::Table;
 #[doc(inline)]
 pub use self::{
     display::DisplayHex,
-    iter::{BytesToHexIter, HexToBytesIter},
+    iter::{BytesToHexIter, HexToBytesIter, OddLengthStringError},
     parse::{FromHex, HexToArrayError, HexToBytesError},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ extern crate alloc;
 
 pub mod buf_encoder;
 pub mod display;
-mod error;
+pub mod error;
 mod iter;
 pub mod parse;
 #[cfg(feature = "serde")]
@@ -65,7 +65,8 @@ pub(crate) use table::Table;
 pub use self::{
     display::DisplayHex,
     iter::{BytesToHexIter, HexToBytesIter, OddLengthStringError},
-    parse::{FromHex, HexToArrayError, HexToBytesError},
+    parse::{FromHex, FromHexError, FromNoPrefixHexError, FromPrefixedHexError, HexToArrayError, InvalidCharError},
+    // Note, we do not re-export inner error types, niche users to get those from `hex::error`.
 };
 
 /// Possible case of hex.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,7 +26,8 @@ pub trait FromHex: Sized {
 
     /// Produces an object from a hex string.
     fn from_hex(s: &str) -> Result<Self, Self::Error> {
-        Self::from_byte_iter(HexToBytesIter::new(s)?)
+        let iter = HexToBytesIter::new(s).map_err(Into::into)?;
+        Self::from_byte_iter(iter)
     }
 }
 


### PR DESCRIPTION
Done on top of #67 and #71

Just the second to last patch (last is API changes), draft for feedback please.

Adds functionality to support printing slices and vectors of bytes backwards as used by `rust-bitcoin`. The current code is definitely a bit klunky.