### PR TITLE
Add support for parsing integer types

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -82,6 +82,10 @@ impl hex_conservative::error::InvalidCharError
 impl hex_conservative::error::InvalidLengthError
 impl hex_conservative::error::OddLengthError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
+impl hex_conservative::parse::FromHex for u16
+impl hex_conservative::parse::FromHex for u32
+impl hex_conservative::parse::FromHex for u64
+impl hex_conservative::parse::FromHex for u8
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -283,6 +287,14 @@ pub fn hex_conservative::serde::deserialize<'de, D, T>(d: D) -> core::result::Re
 pub fn hex_conservative::serde::serialize<S, T>(data: T, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
 pub fn hex_conservative::serde::serialize_lower<S, T>(data: T, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
 pub fn hex_conservative::serde::serialize_upper<S, T>(data: T, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
+pub fn u16::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u16::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u32::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u32::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u64::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u64::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u8::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u8::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
@@ -305,6 +317,7 @@ pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
 pub mod hex_conservative::error
+pub mod hex_conservative::integer
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub mod hex_conservative::serde
@@ -370,3 +383,11 @@ pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Sel
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
 pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type u16::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u16::FromHexError = hex_conservative::error::InvalidCharError
+pub type u32::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u32::FromHexError = hex_conservative::error::InvalidCharError
+pub type u64::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u64::FromHexError = hex_conservative::error::InvalidCharError
+pub type u8::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u8::FromHexError = hex_conservative::error::InvalidCharError

--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -1,54 +1,86 @@
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::HexToVecError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::OddLengthError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::HexToVecError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::OddLengthError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::HexToVecError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToVecError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::OddLengthError> for hex_conservative::error::HexToVecError
 impl core::default::Default for hex_conservative::Case
-impl core::error::Error for hex_conservative::HexToArrayError
-impl core::error::Error for hex_conservative::HexToBytesError
-impl core::error::Error for hex_conservative::OddLengthStringError
+impl core::error::Error for hex_conservative::error::HexToArrayError
+impl core::error::Error for hex_conservative::error::HexToVecError
+impl core::error::Error for hex_conservative::error::InvalidCharError
+impl core::error::Error for hex_conservative::error::InvalidLengthError
+impl core::error::Error for hex_conservative::error::OddLengthError
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::HexToVecError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::OddLengthError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::HexToVecError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::OddLengthError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::HexToVecError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::OddLengthError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToVecError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::HexToVecError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::OddLengthError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::HexToVecError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::OddLengthError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -128,9 +160,11 @@ impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::HexToVecError
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::error::HexToVecError
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
+pub enum hex_conservative::parse::HexToVecError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -162,8 +196,10 @@ pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
 pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn alloc::vec::Vec<u8>::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -180,28 +216,14 @@ pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
-pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> hex_conservative::HexToBytesIter<'a>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -219,30 +241,62 @@ pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> us
 pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::HexToArrayError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::HexToVecError::clone(&self) -> hex_conservative::error::HexToVecError
+pub fn hex_conservative::error::HexToVecError::eq(&self, other: &hex_conservative::error::HexToVecError) -> bool
+pub fn hex_conservative::error::HexToVecError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::OddLengthError) -> Self
+pub fn hex_conservative::error::HexToVecError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidCharError::new(invalid: u8) -> Self
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::OddLengthError::clone(&self) -> hex_conservative::error::OddLengthError
+pub fn hex_conservative::error::OddLengthError::eq(&self, other: &hex_conservative::error::OddLengthError) -> bool
+pub fn hex_conservative::error::OddLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthError::input_string_length(&self) -> usize
+pub fn hex_conservative::error::OddLengthError::new(len: usize) -> Self
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::serde::deserialize<'de, D, T>(d: D) -> core::result::Result<T, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>, T: serde::de::Deserialize<'de> + hex_conservative::parse::FromHex
 pub fn hex_conservative::serde::serialize<S, T>(data: T, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
 pub fn hex_conservative::serde::serialize_lower<S, T>(data: T, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
 pub fn hex_conservative::serde::serialize_upper<S, T>(data: T, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer, T: serde::ser::Serialize + hex_conservative::display::DisplayHex
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -250,15 +304,22 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub mod hex_conservative::serde
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
-pub struct hex_conservative::OddLengthStringError
+pub struct hex_conservative::InvalidCharError
+pub struct hex_conservative::InvalidLengthError
+pub struct hex_conservative::OddLengthError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -294,13 +355,18 @@ pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
 pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
-pub type alloc::vec::Vec<u8>::Error = hex_conservative::HexToBytesError
+pub type [u8; LEN]::FromByteIterError = hex_conservative::error::HexToArrayError
+pub type [u8; LEN]::FromHexError = hex_conservative::error::HexToArrayError
+pub type alloc::vec::Vec<u8>::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type alloc::vec::Vec<u8>::FromHexError = hex_conservative::error::HexToVecError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display

--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -1,41 +1,54 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::error::Error for hex_conservative::HexToArrayError
 impl core::error::Error for hex_conservative::HexToBytesError
+impl core::error::Error for hex_conservative::OddLengthStringError
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -177,13 +190,18 @@ pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -220,11 +238,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -237,6 +255,7 @@ pub mod hex_conservative::prelude
 pub mod hex_conservative::serde
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/alloc.txt
+++ b/api/alloc.txt
@@ -1,51 +1,81 @@
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::HexToVecError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::OddLengthError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::HexToVecError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::OddLengthError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::HexToVecError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToVecError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::OddLengthError> for hex_conservative::error::HexToVecError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::HexToVecError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::OddLengthError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::HexToVecError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::OddLengthError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::HexToVecError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::OddLengthError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToVecError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::HexToVecError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::OddLengthError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::HexToVecError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::OddLengthError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -124,9 +154,11 @@ impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::HexToVecError
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::error::HexToVecError
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
+pub enum hex_conservative::parse::HexToVecError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -158,8 +190,10 @@ pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
 pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn alloc::vec::Vec<u8>::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -176,24 +210,13 @@ pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> hex_conservative::HexToBytesIter<'a>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -211,26 +234,56 @@ pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> us
 pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::HexToVecError::clone(&self) -> hex_conservative::error::HexToVecError
+pub fn hex_conservative::error::HexToVecError::eq(&self, other: &hex_conservative::error::HexToVecError) -> bool
+pub fn hex_conservative::error::HexToVecError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::OddLengthError) -> Self
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidCharError::new(invalid: u8) -> Self
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::OddLengthError::clone(&self) -> hex_conservative::error::OddLengthError
+pub fn hex_conservative::error::OddLengthError::eq(&self, other: &hex_conservative::error::OddLengthError) -> bool
+pub fn hex_conservative::error::OddLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthError::input_string_length(&self) -> usize
+pub fn hex_conservative::error::OddLengthError::new(len: usize) -> Self
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -238,14 +291,21 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
-pub struct hex_conservative::OddLengthStringError
+pub struct hex_conservative::InvalidCharError
+pub struct hex_conservative::InvalidLengthError
+pub struct hex_conservative::OddLengthError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -281,13 +341,18 @@ pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
 pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
-pub type alloc::vec::Vec<u8>::Error = hex_conservative::HexToBytesError
+pub type [u8; LEN]::FromByteIterError = hex_conservative::error::HexToArrayError
+pub type [u8; LEN]::FromHexError = hex_conservative::error::HexToArrayError
+pub type alloc::vec::Vec<u8>::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type alloc::vec::Vec<u8>::FromHexError = hex_conservative::error::HexToVecError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display

--- a/api/alloc.txt
+++ b/api/alloc.txt
@@ -77,6 +77,10 @@ impl hex_conservative::error::InvalidCharError
 impl hex_conservative::error::InvalidLengthError
 impl hex_conservative::error::OddLengthError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
+impl hex_conservative::parse::FromHex for u16
+impl hex_conservative::parse::FromHex for u32
+impl hex_conservative::parse::FromHex for u64
+impl hex_conservative::parse::FromHex for u8
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -270,6 +274,14 @@ pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u16::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u16::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u32::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u32::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u64::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u64::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u8::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u8::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
@@ -292,6 +304,7 @@ pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
 pub mod hex_conservative::error
+pub mod hex_conservative::integer
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
@@ -356,3 +369,11 @@ pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Sel
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
 pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type u16::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u16::FromHexError = hex_conservative::error::InvalidCharError
+pub type u32::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u32::FromHexError = hex_conservative::error::InvalidCharError
+pub type u64::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u64::FromHexError = hex_conservative::error::InvalidCharError
+pub type u8::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u8::FromHexError = hex_conservative::error::InvalidCharError

--- a/api/alloc.txt
+++ b/api/alloc.txt
@@ -1,39 +1,51 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -173,11 +185,15 @@ pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesEr
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -210,11 +226,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -226,6 +242,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/core2.txt
+++ b/api/core2.txt
@@ -76,6 +76,10 @@ impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLength
 impl hex_conservative::error::InvalidCharError
 impl hex_conservative::error::InvalidLengthError
 impl hex_conservative::error::OddLengthError
+impl hex_conservative::parse::FromHex for u16
+impl hex_conservative::parse::FromHex for u32
+impl hex_conservative::parse::FromHex for u64
+impl hex_conservative::parse::FromHex for u8
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -254,6 +258,14 @@ pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u16::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u16::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u32::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u32::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u64::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u64::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u8::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u8::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
@@ -276,6 +288,7 @@ pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
 pub mod hex_conservative::error
+pub mod hex_conservative::integer
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
@@ -337,3 +350,11 @@ pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Sel
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
 pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type u16::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u16::FromHexError = hex_conservative::error::InvalidCharError
+pub type u32::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u32::FromHexError = hex_conservative::error::InvalidCharError
+pub type u64::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u64::FromHexError = hex_conservative::error::InvalidCharError
+pub type u8::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u8::FromHexError = hex_conservative::error::InvalidCharError

--- a/api/core2.txt
+++ b/api/core2.txt
@@ -1,39 +1,51 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -165,12 +177,16 @@ pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesEr
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> core2::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -195,11 +211,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -211,6 +227,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/core2.txt
+++ b/api/core2.txt
@@ -1,51 +1,81 @@
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::HexToVecError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::OddLengthError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::HexToVecError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::OddLengthError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::HexToVecError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToVecError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::OddLengthError> for hex_conservative::error::HexToVecError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::HexToVecError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::OddLengthError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::HexToVecError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::OddLengthError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::HexToVecError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::OddLengthError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToVecError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::HexToVecError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::OddLengthError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::HexToVecError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::OddLengthError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -123,9 +153,11 @@ impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::HexToVecError
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::error::HexToVecError
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
+pub enum hex_conservative::parse::HexToVecError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -155,7 +187,8 @@ pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -168,25 +201,14 @@ pub fn hex_conservative::Case::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> hex_conservative::HexToBytesIter<'a>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> core2::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -200,22 +222,52 @@ pub fn hex_conservative::display::DisplayArray<'a, LEN>::fmt(&self, f: &mut core
 pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::HexToVecError::clone(&self) -> hex_conservative::error::HexToVecError
+pub fn hex_conservative::error::HexToVecError::eq(&self, other: &hex_conservative::error::HexToVecError) -> bool
+pub fn hex_conservative::error::HexToVecError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::OddLengthError) -> Self
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidCharError::new(invalid: u8) -> Self
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::OddLengthError::clone(&self) -> hex_conservative::error::OddLengthError
+pub fn hex_conservative::error::OddLengthError::eq(&self, other: &hex_conservative::error::OddLengthError) -> bool
+pub fn hex_conservative::error::OddLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthError::input_string_length(&self) -> usize
+pub fn hex_conservative::error::OddLengthError::new(len: usize) -> Self
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -223,14 +275,21 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
-pub struct hex_conservative::OddLengthStringError
+pub struct hex_conservative::InvalidCharError
+pub struct hex_conservative::InvalidLengthError
+pub struct hex_conservative::OddLengthError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -265,12 +324,16 @@ pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
+pub type [u8; LEN]::FromByteIterError = hex_conservative::error::HexToArrayError
+pub type [u8; LEN]::FromHexError = hex_conservative::error::HexToArrayError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display

--- a/api/default-features.txt
+++ b/api/default-features.txt
@@ -1,41 +1,54 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::error::Error for hex_conservative::HexToArrayError
 impl core::error::Error for hex_conservative::HexToBytesError
+impl core::error::Error for hex_conservative::OddLengthStringError
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -177,13 +190,18 @@ pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -216,11 +234,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -232,6 +250,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/default-features.txt
+++ b/api/default-features.txt
@@ -82,6 +82,10 @@ impl hex_conservative::error::InvalidCharError
 impl hex_conservative::error::InvalidLengthError
 impl hex_conservative::error::OddLengthError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
+impl hex_conservative::parse::FromHex for u16
+impl hex_conservative::parse::FromHex for u32
+impl hex_conservative::parse::FromHex for u64
+impl hex_conservative::parse::FromHex for u8
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -279,6 +283,14 @@ pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u16::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u16::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u32::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u32::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u64::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u64::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u8::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u8::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
@@ -301,6 +313,7 @@ pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
 pub mod hex_conservative::error
+pub mod hex_conservative::integer
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
@@ -365,3 +378,11 @@ pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Sel
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
 pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type u16::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u16::FromHexError = hex_conservative::error::InvalidCharError
+pub type u32::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u32::FromHexError = hex_conservative::error::InvalidCharError
+pub type u64::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u64::FromHexError = hex_conservative::error::InvalidCharError
+pub type u8::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u8::FromHexError = hex_conservative::error::InvalidCharError

--- a/api/default-features.txt
+++ b/api/default-features.txt
@@ -1,54 +1,86 @@
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::HexToVecError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::OddLengthError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::HexToVecError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::OddLengthError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::HexToVecError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToVecError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::OddLengthError> for hex_conservative::error::HexToVecError
 impl core::default::Default for hex_conservative::Case
-impl core::error::Error for hex_conservative::HexToArrayError
-impl core::error::Error for hex_conservative::HexToBytesError
-impl core::error::Error for hex_conservative::OddLengthStringError
+impl core::error::Error for hex_conservative::error::HexToArrayError
+impl core::error::Error for hex_conservative::error::HexToVecError
+impl core::error::Error for hex_conservative::error::InvalidCharError
+impl core::error::Error for hex_conservative::error::InvalidLengthError
+impl core::error::Error for hex_conservative::error::OddLengthError
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::HexToVecError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::OddLengthError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::HexToVecError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::OddLengthError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::HexToVecError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::OddLengthError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToVecError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::HexToVecError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::OddLengthError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::HexToVecError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::OddLengthError
 impl hex_conservative::parse::FromHex for alloc::vec::Vec<u8>
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
@@ -128,9 +160,11 @@ impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::HexToVecError
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::error::HexToVecError
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
+pub enum hex_conservative::parse::HexToVecError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -162,8 +196,10 @@ pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
 pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
 pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn alloc::vec::Vec<u8>::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn alloc::vec::Vec<u8>::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -180,28 +216,14 @@ pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToArrayError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
-pub fn hex_conservative::HexToBytesError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> hex_conservative::HexToBytesIter<'a>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::read(&mut self, buf: &mut [u8]) -> std::io::error::Result<usize>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::OddLengthStringError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -219,26 +241,58 @@ pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> us
 pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::HexToArrayError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::HexToVecError::clone(&self) -> hex_conservative::error::HexToVecError
+pub fn hex_conservative::error::HexToVecError::eq(&self, other: &hex_conservative::error::HexToVecError) -> bool
+pub fn hex_conservative::error::HexToVecError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::OddLengthError) -> Self
+pub fn hex_conservative::error::HexToVecError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidCharError::new(invalid: u8) -> Self
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::OddLengthError::clone(&self) -> hex_conservative::error::OddLengthError
+pub fn hex_conservative::error::OddLengthError::eq(&self, other: &hex_conservative::error::OddLengthError) -> bool
+pub fn hex_conservative::error::OddLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthError::input_string_length(&self) -> usize
+pub fn hex_conservative::error::OddLengthError::new(len: usize) -> Self
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
 pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -246,14 +300,21 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
-pub struct hex_conservative::OddLengthStringError
+pub struct hex_conservative::InvalidCharError
+pub struct hex_conservative::InvalidLengthError
+pub struct hex_conservative::OddLengthError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -289,13 +350,18 @@ pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
 pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
-pub type alloc::vec::Vec<u8>::Error = hex_conservative::HexToBytesError
+pub type [u8; LEN]::FromByteIterError = hex_conservative::error::HexToArrayError
+pub type [u8; LEN]::FromHexError = hex_conservative::error::HexToArrayError
+pub type alloc::vec::Vec<u8>::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type alloc::vec::Vec<u8>::FromHexError = hex_conservative::error::HexToVecError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display

--- a/api/no-default-features.txt
+++ b/api/no-default-features.txt
@@ -1,51 +1,81 @@
 impl core::clone::Clone for hex_conservative::Case
-impl core::clone::Clone for hex_conservative::HexToArrayError
-impl core::clone::Clone for hex_conservative::HexToBytesError
-impl core::clone::Clone for hex_conservative::OddLengthStringError
+impl core::clone::Clone for hex_conservative::error::HexToArrayError
+impl core::clone::Clone for hex_conservative::error::HexToVecError
+impl core::clone::Clone for hex_conservative::error::InvalidCharError
+impl core::clone::Clone for hex_conservative::error::InvalidLengthError
+impl core::clone::Clone for hex_conservative::error::OddLengthError
 impl core::cmp::Eq for hex_conservative::Case
-impl core::cmp::Eq for hex_conservative::HexToArrayError
-impl core::cmp::Eq for hex_conservative::HexToBytesError
-impl core::cmp::Eq for hex_conservative::OddLengthStringError
+impl core::cmp::Eq for hex_conservative::error::HexToArrayError
+impl core::cmp::Eq for hex_conservative::error::HexToVecError
+impl core::cmp::Eq for hex_conservative::error::InvalidCharError
+impl core::cmp::Eq for hex_conservative::error::InvalidLengthError
+impl core::cmp::Eq for hex_conservative::error::OddLengthError
 impl core::cmp::PartialEq for hex_conservative::Case
-impl core::cmp::PartialEq for hex_conservative::HexToArrayError
-impl core::cmp::PartialEq for hex_conservative::HexToBytesError
-impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
-impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
-impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::error::HexToArrayError
+impl core::cmp::PartialEq for hex_conservative::error::HexToVecError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidCharError
+impl core::cmp::PartialEq for hex_conservative::error::InvalidLengthError
+impl core::cmp::PartialEq for hex_conservative::error::OddLengthError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::InvalidCharError> for hex_conservative::error::HexToVecError
+impl core::convert::From<hex_conservative::error::InvalidLengthError> for hex_conservative::error::HexToArrayError
+impl core::convert::From<hex_conservative::error::OddLengthError> for hex_conservative::error::HexToVecError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
-impl core::fmt::Debug for hex_conservative::HexToArrayError
-impl core::fmt::Debug for hex_conservative::HexToBytesError
-impl core::fmt::Debug for hex_conservative::OddLengthStringError
-impl core::fmt::Display for hex_conservative::HexToArrayError
-impl core::fmt::Display for hex_conservative::HexToBytesError
-impl core::fmt::Display for hex_conservative::OddLengthStringError
+impl core::fmt::Debug for hex_conservative::error::HexToArrayError
+impl core::fmt::Debug for hex_conservative::error::HexToVecError
+impl core::fmt::Debug for hex_conservative::error::InvalidCharError
+impl core::fmt::Debug for hex_conservative::error::InvalidLengthError
+impl core::fmt::Debug for hex_conservative::error::OddLengthError
+impl core::fmt::Display for hex_conservative::error::HexToArrayError
+impl core::fmt::Display for hex_conservative::error::HexToVecError
+impl core::fmt::Display for hex_conservative::error::InvalidCharError
+impl core::fmt::Display for hex_conservative::error::InvalidLengthError
+impl core::fmt::Display for hex_conservative::error::OddLengthError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
+impl core::marker::Copy for hex_conservative::error::InvalidCharError
+impl core::marker::Copy for hex_conservative::error::InvalidLengthError
+impl core::marker::Copy for hex_conservative::error::OddLengthError
 impl core::marker::Send for hex_conservative::Case
-impl core::marker::Send for hex_conservative::HexToArrayError
-impl core::marker::Send for hex_conservative::HexToBytesError
-impl core::marker::Send for hex_conservative::OddLengthStringError
+impl core::marker::Send for hex_conservative::error::HexToArrayError
+impl core::marker::Send for hex_conservative::error::HexToVecError
+impl core::marker::Send for hex_conservative::error::InvalidCharError
+impl core::marker::Send for hex_conservative::error::InvalidLengthError
+impl core::marker::Send for hex_conservative::error::OddLengthError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
-impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
-impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
-impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToArrayError
+impl core::marker::StructuralPartialEq for hex_conservative::error::HexToVecError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidCharError
+impl core::marker::StructuralPartialEq for hex_conservative::error::InvalidLengthError
+impl core::marker::StructuralPartialEq for hex_conservative::error::OddLengthError
 impl core::marker::Sync for hex_conservative::Case
-impl core::marker::Sync for hex_conservative::HexToArrayError
-impl core::marker::Sync for hex_conservative::HexToBytesError
-impl core::marker::Sync for hex_conservative::OddLengthStringError
+impl core::marker::Sync for hex_conservative::error::HexToArrayError
+impl core::marker::Sync for hex_conservative::error::HexToVecError
+impl core::marker::Sync for hex_conservative::error::InvalidCharError
+impl core::marker::Sync for hex_conservative::error::InvalidLengthError
+impl core::marker::Sync for hex_conservative::error::OddLengthError
 impl core::marker::Unpin for hex_conservative::Case
-impl core::marker::Unpin for hex_conservative::HexToArrayError
-impl core::marker::Unpin for hex_conservative::HexToBytesError
-impl core::marker::Unpin for hex_conservative::OddLengthStringError
+impl core::marker::Unpin for hex_conservative::error::HexToArrayError
+impl core::marker::Unpin for hex_conservative::error::HexToVecError
+impl core::marker::Unpin for hex_conservative::error::InvalidCharError
+impl core::marker::Unpin for hex_conservative::error::InvalidLengthError
+impl core::marker::Unpin for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::error::OddLengthError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
-impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToArrayError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::HexToVecError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidCharError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::InvalidLengthError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLengthError
+impl hex_conservative::error::InvalidCharError
+impl hex_conservative::error::InvalidLengthError
+impl hex_conservative::error::OddLengthError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -122,9 +152,11 @@ impl<const CAP: usize> hex_conservative::buf_encoder::BufEncoder<CAP>
 impl<const LEN: usize> hex_conservative::parse::FromHex for [u8; LEN]
 pub enum hex_conservative::Case
 pub enum hex_conservative::HexToArrayError
-pub enum hex_conservative::HexToBytesError
+pub enum hex_conservative::HexToVecError
+pub enum hex_conservative::error::HexToArrayError
+pub enum hex_conservative::error::HexToVecError
 pub enum hex_conservative::parse::HexToArrayError
-pub enum hex_conservative::parse::HexToBytesError
+pub enum hex_conservative::parse::HexToVecError
 pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
@@ -154,7 +186,8 @@ pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
 pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::as_hex(self) -> Self::Display
 pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn [u8; LEN]::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 pub fn hex_conservative::BytesToHexIter<I>::new(iter: I) -> hex_conservative::BytesToHexIter<I>
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
@@ -167,24 +200,13 @@ pub fn hex_conservative::Case::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> c
 pub fn hex_conservative::Case::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-pub fn hex_conservative::HexToArrayError::clone(&self) -> hex_conservative::HexToArrayError
-pub fn hex_conservative::HexToArrayError::eq(&self, other: &hex_conservative::HexToArrayError) -> bool
-pub fn hex_conservative::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesError) -> Self
-pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
-pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
-pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
+pub fn hex_conservative::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
-pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
-pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> hex_conservative::HexToBytesIter<'a>
+pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
+pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::error::InvalidCharError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
-pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
-pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
-pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -198,22 +220,52 @@ pub fn hex_conservative::display::DisplayArray<'a, LEN>::fmt(&self, f: &mut core
 pub fn hex_conservative::display::DisplayByteSlice<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::error::HexToArrayError::clone(&self) -> hex_conservative::error::HexToArrayError
+pub fn hex_conservative::error::HexToArrayError::eq(&self, other: &hex_conservative::error::HexToArrayError) -> bool
+pub fn hex_conservative::error::HexToArrayError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToArrayError::from(e: hex_conservative::error::InvalidLengthError) -> Self
+pub fn hex_conservative::error::HexToVecError::clone(&self) -> hex_conservative::error::HexToVecError
+pub fn hex_conservative::error::HexToVecError::eq(&self, other: &hex_conservative::error::HexToVecError) -> bool
+pub fn hex_conservative::error::HexToVecError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::InvalidCharError) -> Self
+pub fn hex_conservative::error::HexToVecError::from(e: hex_conservative::error::OddLengthError) -> Self
+pub fn hex_conservative::error::InvalidCharError::clone(&self) -> hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::eq(&self, other: &hex_conservative::error::InvalidCharError) -> bool
+pub fn hex_conservative::error::InvalidCharError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
+pub fn hex_conservative::error::InvalidCharError::new(invalid: u8) -> Self
+pub fn hex_conservative::error::InvalidLengthError::clone(&self) -> hex_conservative::error::InvalidLengthError
+pub fn hex_conservative::error::InvalidLengthError::eq(&self, other: &hex_conservative::error::InvalidLengthError) -> bool
+pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
+pub fn hex_conservative::error::InvalidLengthError::new(got: usize, expected: usize) -> Self
+pub fn hex_conservative::error::OddLengthError::clone(&self) -> hex_conservative::error::OddLengthError
+pub fn hex_conservative::error::OddLengthError::eq(&self, other: &hex_conservative::error::OddLengthError) -> bool
+pub fn hex_conservative::error::OddLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::error::OddLengthError::input_string_length(&self) -> usize
+pub fn hex_conservative::error::OddLengthError::new(len: usize) -> Self
+pub fn hex_conservative::parse::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::parse::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::Error> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::HexToBytesError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
-pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
-pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
-pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
-pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
-pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
+pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::error::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::error::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::error::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
+pub hex_conservative::parse::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToArrayError::InvalidLength(hex_conservative::error::InvalidLengthError)
+pub hex_conservative::parse::HexToVecError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub hex_conservative::parse::HexToVecError::OddLength(hex_conservative::error::OddLengthError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -221,14 +273,21 @@ pub macro hex_conservative::write_err!
 pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
+pub mod hex_conservative::error
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
-pub struct hex_conservative::OddLengthStringError
+pub struct hex_conservative::InvalidCharError
+pub struct hex_conservative::InvalidLengthError
+pub struct hex_conservative::OddLengthError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>
+pub struct hex_conservative::error::InvalidCharError
+pub struct hex_conservative::error::InvalidLengthError
+pub struct hex_conservative::error::OddLengthError
+pub struct hex_conservative::parse::InvalidCharError
 pub trait hex_conservative::DisplayHex: core::marker::Copy + sealed::IsRef
 pub trait hex_conservative::FromHex: core::marker::Sized
 pub trait hex_conservative::display::DisplayHex: core::marker::Copy + sealed::IsRef
@@ -263,12 +322,16 @@ pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$le
 pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
 pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub type [u8; LEN]::Error = hex_conservative::HexToArrayError
+pub type [u8; LEN]::FromByteIterError = hex_conservative::error::HexToArrayError
+pub type [u8; LEN]::FromHexError = hex_conservative::error::HexToArrayError
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
-pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::HexToBytesError>
+pub type hex_conservative::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::HexToBytesIter<'a>::Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>
 pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::parse::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub type hex_conservative::prelude::FromHex::Error: core::convert::From<hex_conservative::HexToBytesError> + core::marker::Sized + core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
+pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display

--- a/api/no-default-features.txt
+++ b/api/no-default-features.txt
@@ -1,39 +1,51 @@
 impl core::clone::Clone for hex_conservative::Case
 impl core::clone::Clone for hex_conservative::HexToArrayError
 impl core::clone::Clone for hex_conservative::HexToBytesError
+impl core::clone::Clone for hex_conservative::OddLengthStringError
 impl core::cmp::Eq for hex_conservative::Case
 impl core::cmp::Eq for hex_conservative::HexToArrayError
 impl core::cmp::Eq for hex_conservative::HexToBytesError
+impl core::cmp::Eq for hex_conservative::OddLengthStringError
 impl core::cmp::PartialEq for hex_conservative::Case
 impl core::cmp::PartialEq for hex_conservative::HexToArrayError
 impl core::cmp::PartialEq for hex_conservative::HexToBytesError
+impl core::cmp::PartialEq for hex_conservative::OddLengthStringError
 impl core::convert::From<hex_conservative::HexToBytesError> for hex_conservative::HexToArrayError
+impl core::convert::From<hex_conservative::OddLengthStringError> for hex_conservative::HexToBytesError
 impl core::default::Default for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::Case
 impl core::fmt::Debug for hex_conservative::HexToArrayError
 impl core::fmt::Debug for hex_conservative::HexToBytesError
+impl core::fmt::Debug for hex_conservative::OddLengthStringError
 impl core::fmt::Display for hex_conservative::HexToArrayError
 impl core::fmt::Display for hex_conservative::HexToBytesError
+impl core::fmt::Display for hex_conservative::OddLengthStringError
 impl core::hash::Hash for hex_conservative::Case
 impl core::marker::Copy for hex_conservative::Case
 impl core::marker::Send for hex_conservative::Case
 impl core::marker::Send for hex_conservative::HexToArrayError
 impl core::marker::Send for hex_conservative::HexToBytesError
+impl core::marker::Send for hex_conservative::OddLengthStringError
 impl core::marker::StructuralPartialEq for hex_conservative::Case
 impl core::marker::StructuralPartialEq for hex_conservative::HexToArrayError
 impl core::marker::StructuralPartialEq for hex_conservative::HexToBytesError
+impl core::marker::StructuralPartialEq for hex_conservative::OddLengthStringError
 impl core::marker::Sync for hex_conservative::Case
 impl core::marker::Sync for hex_conservative::HexToArrayError
 impl core::marker::Sync for hex_conservative::HexToBytesError
+impl core::marker::Sync for hex_conservative::OddLengthStringError
 impl core::marker::Unpin for hex_conservative::Case
 impl core::marker::Unpin for hex_conservative::HexToArrayError
 impl core::marker::Unpin for hex_conservative::HexToBytesError
+impl core::marker::Unpin for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::OddLengthStringError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Case
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToArrayError
 impl core::panic::unwind_safe::UnwindSafe for hex_conservative::HexToBytesError
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::OddLengthStringError
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -164,11 +176,15 @@ pub fn hex_conservative::HexToArrayError::from(e: hex_conservative::HexToBytesEr
 pub fn hex_conservative::HexToBytesError::clone(&self) -> hex_conservative::HexToBytesError
 pub fn hex_conservative::HexToBytesError::eq(&self, other: &hex_conservative::HexToBytesError) -> bool
 pub fn hex_conservative::HexToBytesError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn hex_conservative::HexToBytesError::from(e: hex_conservative::OddLengthStringError) -> Self
 pub fn hex_conservative::HexToBytesIter<'a>::len(&self) -> usize
-pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::HexToBytesError>
+pub fn hex_conservative::HexToBytesIter<'a>::new(s: &'a str) -> core::result::Result<hex_conservative::HexToBytesIter<'a>, hex_conservative::OddLengthStringError>
 pub fn hex_conservative::HexToBytesIter<'a>::next(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::next_back(&mut self) -> core::option::Option<core::result::Result<u8, hex_conservative::HexToBytesError>>
 pub fn hex_conservative::HexToBytesIter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn hex_conservative::OddLengthStringError::clone(&self) -> hex_conservative::OddLengthStringError
+pub fn hex_conservative::OddLengthStringError::eq(&self, other: &hex_conservative::OddLengthStringError) -> bool
+pub fn hex_conservative::OddLengthStringError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::as_str(&self) -> &str
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::clear(&mut self)
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
@@ -193,11 +209,11 @@ pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub hex_conservative::parse::HexToArrayError::Conversion(hex_conservative::HexToBytesError)
 pub hex_conservative::parse::HexToArrayError::InvalidLength(InvalidLengthError)
 pub hex_conservative::parse::HexToBytesError::InvalidChar(InvalidCharError)
-pub hex_conservative::parse::HexToBytesError::OddLengthString(OddLengthStringError)
+pub hex_conservative::parse::HexToBytesError::OddLengthString(hex_conservative::OddLengthStringError)
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::test_hex_unwrap!
@@ -209,6 +225,7 @@ pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
 pub struct hex_conservative::HexToBytesIter<'a>
+pub struct hex_conservative::OddLengthStringError
 pub struct hex_conservative::buf_encoder::BufEncoder<const CAP: usize>
 pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
 pub struct hex_conservative::display::DisplayByteSlice<'a>

--- a/api/no-default-features.txt
+++ b/api/no-default-features.txt
@@ -76,6 +76,10 @@ impl core::panic::unwind_safe::UnwindSafe for hex_conservative::error::OddLength
 impl hex_conservative::error::InvalidCharError
 impl hex_conservative::error::InvalidLengthError
 impl hex_conservative::error::OddLengthError
+impl hex_conservative::parse::FromHex for u16
+impl hex_conservative::parse::FromHex for u32
+impl hex_conservative::parse::FromHex for u64
+impl hex_conservative::parse::FromHex for u8
 impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
 impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
@@ -252,6 +256,14 @@ pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
 pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
 pub fn hex_conservative::prelude::FromHex::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
 pub fn hex_conservative::prelude::FromHex::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u16::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u16::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u32::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u32::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u64::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u64::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
+pub fn u8::from_byte_iter<I>(iter: I) -> core::result::Result<Self, Self::FromByteIterError> where I: core::iter::traits::iterator::Iterator<Item = core::result::Result<u8, hex_conservative::error::InvalidCharError>> + core::iter::traits::exact_size::ExactSizeIterator + core::iter::traits::double_ended::DoubleEndedIterator
+pub fn u8::from_hex(s: &str) -> core::result::Result<Self, Self::FromHexError>
 pub hex_conservative::Case::Lower
 pub hex_conservative::Case::Upper
 pub hex_conservative::HexToArrayError::InvalidChar(hex_conservative::error::InvalidCharError)
@@ -274,6 +286,7 @@ pub mod hex_conservative
 pub mod hex_conservative::buf_encoder
 pub mod hex_conservative::display
 pub mod hex_conservative::error
+pub mod hex_conservative::integer
 pub mod hex_conservative::parse
 pub mod hex_conservative::prelude
 pub struct hex_conservative::BytesToHexIter<I: core::iter::traits::iterator::Iterator<Item = u8>>
@@ -335,3 +348,11 @@ pub type hex_conservative::parse::FromHex::FromHexError: core::convert::From<Sel
 pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
 pub type hex_conservative::prelude::FromHex::FromByteIterError: core::fmt::Debug + core::fmt::Display
 pub type hex_conservative::prelude::FromHex::FromHexError: core::convert::From<Self::FromByteIterError> + core::fmt::Debug + core::fmt::Display
+pub type u16::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u16::FromHexError = hex_conservative::error::InvalidCharError
+pub type u32::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u32::FromHexError = hex_conservative::error::InvalidCharError
+pub type u64::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u64::FromHexError = hex_conservative::error::InvalidCharError
+pub type u8::FromByteIterError = hex_conservative::error::InvalidCharError
+pub type u8::FromHexError = hex_conservative::error::InvalidCharError

--- a/examples/wrap_array_display_hex_trait.rs
+++ b/examples/wrap_array_display_hex_trait.rs
@@ -5,7 +5,7 @@
 //! For an example using the standard library `fmt` traits see `./wrap_array_fmt_traits.rs`.
 
 use hex_conservative::display::DisplayArray;
-use hex_conservative::{DisplayHex, FromHex, HexToArrayError, HexToBytesError};
+use hex_conservative::{DisplayHex, FromHex, HexToArrayError, InvalidCharError};
 
 fn main() {
     let hex = "00000000cafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
@@ -18,8 +18,9 @@ fn main() {
     println!("LowerHex: {:x}", array.as_hex());
     println!("UpperHex: {:X}", array.as_hex());
     println!("Display: {}", array.as_hex());
+    println!("Alternate: {:#}", wrap.as_hex());
     println!("Debug: {:?}", array.as_hex());
-    println!("Debug pretty: {:#?}", array.as_hex());
+    println!("Alternate: {:#?}", array.as_hex());
 
     println!("\n");
 
@@ -29,8 +30,9 @@ fn main() {
     println!("LowerHex: {:x}", wrap.as_hex());
     println!("UpperHex: {:X}", wrap.as_hex());
     println!("Display: {}", wrap.as_hex());
+    println!("Alternate: {:#}", wrap.as_hex());
     println!("Debug: {:?}", wrap.as_hex());
-    println!("Debug pretty: {:#?}", wrap.as_hex());
+    println!("Alternate: {:#?}", wrap.as_hex());
 
     #[cfg(feature = "alloc")]
     {
@@ -45,14 +47,17 @@ fn main() {
 pub struct Wrap([u8; 32]);
 
 impl FromHex for Wrap {
-    type Error = HexToArrayError;
+    type FromByteIterError = HexToArrayError;
+    type FromHexError = HexToArrayError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::FromByteIterError>
     where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, InvalidCharError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         Ok(Self(FromHex::from_byte_iter(iter)?))
     }
+
+    fn from_hex(s: &str) -> Result<Self, Self::FromHexError> { Ok(Self(FromHex::from_hex(s)?)) }
 }
 
 /// Use `DisplayArray` to display the `Wrap` type.

--- a/examples/wrap_array_fmt_traits.rs
+++ b/examples/wrap_array_fmt_traits.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Hex encode/decode a type that wraps an array - using implementations of the standard library
+//! Hex encode/decode a type that wraps an array - using implementations of the standard library `fmt` traits.
 //!
-//! `fmt` traits. For an example using the `DisplayHex` trait see `./wrap_array_display_hex.rs`.
+//! For an example using the `DisplayHex` trait see `./wrap_array_display_hex.rs`.
 
 use core::fmt;
 use core::str::FromStr;
@@ -20,8 +20,9 @@ fn main() {
     println!("LowerHex: {:x}", array.as_hex());
     println!("UpperHex: {:X}", array.as_hex());
     println!("Display: {}", array.as_hex());
+    println!("Alternate: {:#}", array.as_hex());
     println!("Debug: {:?}", array.as_hex());
-    println!("Debug pretty: {:#?}", array.as_hex());
+    println!("Alternate: {:#?}", array.as_hex());
 
     println!("\n");
 
@@ -31,8 +32,9 @@ fn main() {
     println!("LowerHex: {:x}", wrap);
     println!("UpperHex: {:X}", wrap);
     println!("Display: {}", wrap);
+    println!("Alternate: {:#}", wrap);
     println!("Debug: {:?}", wrap);
-    println!("Debug pretty: {:#?}", wrap);
+    println!("Alternate: {:#?}", wrap);
 
     // We cannot call `to_lower_hex_string` on the wrapped type to allocate a string, if you wish to
     // use that trait method see `./wrap_array_display_hex_trait.rs`.

--- a/fuzz/fuzz_targets/hex.rs
+++ b/fuzz/fuzz_targets/hex.rs
@@ -1,14 +1,19 @@
+//! This is based on `examples::hexy`.
+
 use std::fmt;
 use std::str::FromStr;
 
-use hex::{fmt_hex_exact, Case, FromHex, HexToArrayError, HexToBytesError};
+use hex::{
+    fmt_hex_exact, Case, FromHex, HexToArrayError, HexToBytesIter, InvalidCharError,
+    InvalidLengthError,
+};
 use honggfuzz::fuzz;
 
 const LEN: usize = 32; // Arbitrary amount of data.
 
 /// A struct that always uses hex when in string form.
 pub struct Hexy {
-    // Some opaque data.
+    // Some opaque data, this exampled is explicitly meant to be more than just wrapping an array
     data: [u8; LEN],
 }
 
@@ -22,7 +27,7 @@ impl fmt::Display for Hexy {
 }
 
 impl FromStr for Hexy {
-    type Err = HexToArrayError;
+    type Err = CustomFromHexError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> { Hexy::from_hex(s) }
 }
@@ -38,18 +43,82 @@ impl fmt::UpperHex for Hexy {
         fmt_hex_exact!(f, 32, self.as_bytes(), Case::Upper)
     }
 }
-
 impl FromHex for Hexy {
-    type Error = HexToArrayError;
+    type FromByteIterError = CustomFromByteIterError;
+    type FromHexError = CustomFromHexError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::FromByteIterError>
     where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, InvalidCharError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         // Errors if the iterator is the wrong length.
         let a = <[u8; 32] as FromHex>::from_byte_iter(iter)?;
+
+        // An example of some application specific error.
+        if a == [0; 32] {
+            return Err(CustomFromByteIterError::AllZeros);
+        }
+
         Ok(Hexy { data: a })
     }
+
+    fn from_hex(s: &str) -> Result<Self, Self::FromHexError> {
+        let expected = 32 * 2; // 2 hex characters per byte.
+
+        // We don't want to any padding so we check the length.
+        if s.len() != expected {
+            return Err(
+                HexToArrayError::InvalidLength(InvalidLengthError::new(s.len(), expected)).into()
+            );
+        }
+
+        let iter = HexToBytesIter::new(s);
+        Ok(Self::from_byte_iter(iter)?)
+    }
+}
+
+/// Example error returned `from_bytes_iter`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CustomFromByteIterError {
+    /// Invalid hex to bytes conversion.
+    Hex(HexToArrayError),
+    /// Some other application/type specific error case.
+    AllZeros,
+}
+
+impl fmt::Display for CustomFromByteIterError {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result { todo!() }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CustomFromByteIterError {}
+
+impl From<HexToArrayError> for CustomFromByteIterError {
+    fn from(e: HexToArrayError) -> Self { Self::Hex(e) }
+}
+
+/// Example error returned `from_hex`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CustomFromHexError {
+    /// Invalid hex to bytes conversion.
+    Hex(HexToArrayError),
+    /// Custom conversion error.
+    Custom(CustomFromByteIterError),
+}
+
+impl fmt::Display for CustomFromHexError {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result { todo!() }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CustomFromHexError {}
+
+impl From<HexToArrayError> for CustomFromHexError {
+    fn from(e: HexToArrayError) -> Self { Self::Hex(e) }
+}
+
+impl From<CustomFromByteIterError> for CustomFromHexError {
+    fn from(e: CustomFromByteIterError) -> Self { Self::Custom(e) }
 }
 
 fn do_test(data: &[u8]) {

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Supports parsing integer types as hex.
+
+use crate::error::InvalidCharError;
+use crate::iter::HexToBytesIter;
+use crate::prelude::*;
+
+macro_rules! impl_from_hex_for_int {
+    ($ty:ty, $len:literal) => {
+        impl FromHex for $ty {
+            type FromByteIterError = InvalidCharError;
+            type FromHexError = InvalidCharError;
+
+            #[inline]
+            fn from_byte_iter<I>(iter: I) -> Result<Self, Self::FromByteIterError>
+            where
+                I: Iterator<Item = Result<u8, InvalidCharError>>
+                    + ExactSizeIterator
+                    + DoubleEndedIterator,
+            {
+                let mut buf = [0_u8; $len];
+                for (i, byte) in iter.rev().enumerate() {
+                    let index = $len - 1 - i;
+                    buf[index] = byte?;
+                }
+                Ok(<$ty>::from_be_bytes(buf))
+            }
+
+            #[inline]
+            #[rustfmt::skip]
+            fn from_hex(s: &str) -> Result<Self, Self::FromHexError> {
+                let s = if s.starts_with("0x") || s.starts_with("0X") { &s[2..] } else { s };
+                let iter = HexToBytesIter::new(s);
+                Self::from_byte_iter(iter)
+            }
+        }
+    };
+}
+impl_from_hex_for_int!(u8, 1);
+impl_from_hex_for_int!(u16, 2);
+impl_from_hex_for_int!(u32, 4);
+impl_from_hex_for_int!(u64, 8);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_u8() {
+        assert_eq!(u8::from_hex("1").expect("failed to parse u8"), 1);
+    }
+
+    #[test]
+    fn basic_u16() {
+        assert_eq!(u16::from_hex("1").expect("failed to parse u16"), 1);
+    }
+
+    #[test]
+    fn basic_u32() {
+        assert_eq!(u32::from_hex("1").expect("failed to parse u32"), 1);
+    }
+
+    #[test]
+    fn basic_u64() {
+        assert_eq!(u64::from_hex("1").expect("failed to parse u64"), 1);
+    }
+
+    macro_rules! check_u32_hex {
+        ($($test_name:ident, $hex:literal, $expected:literal);* $(;)?) => {
+            $(
+                #[test]
+                fn $test_name() {
+                    assert_eq!(u32::from_hex($hex).expect("failed to parse hex"), $expected)
+                }
+            )*
+        }
+    }
+    check_u32_hex! {
+        check_u32_0, "1", 1;
+        check_u32_1, "01", 1;
+        check_u32_2, "0x1", 1;
+        check_u32_3, "0x01", 1;
+        check_u32_4, "0xdeadbeef", 3735928559;
+        check_u32_5, "deadbeef", 3735928559;
+        check_u32_6, "DEADBEEF", 3735928559;
+        check_u32_7, "0XDEADBEEF", 3735928559;
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -10,10 +10,10 @@ use std::io;
 #[cfg(all(feature = "core2", not(feature = "std")))]
 use core2::io;
 
-use crate::error::{InvalidCharError, OddLengthStringError};
+use crate::error::InvalidCharError;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::HexToBytesError;
+pub use crate::error::{HexToBytesError, OddLengthStringError};
 
 /// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
 pub struct HexToBytesIter<'a> {
@@ -34,9 +34,9 @@ impl<'a> HexToBytesIter<'a> {
     ///
     /// If the input string is of odd length.
     #[inline]
-    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, HexToBytesError> {
+    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, OddLengthStringError> {
         if s.len() % 2 != 0 {
-            Err(OddLengthStringError { len: s.len() }.into())
+            Err(OddLengthStringError { len: s.len() })
         } else {
             Ok(HexToBytesIter { iter: s.bytes() })
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ extern crate alloc;
 pub mod buf_encoder;
 pub mod display;
 pub mod error;
+pub mod integer;
 mod iter;
 pub mod parse;
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) use table::Table;
 #[doc(inline)]
 pub use self::{
     display::DisplayHex,
-    iter::{BytesToHexIter, HexToBytesIter},
+    iter::{BytesToHexIter, HexToBytesIter, OddLengthStringError},
     parse::{FromHex, HexToArrayError, HexToBytesError},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ extern crate alloc;
 
 pub mod buf_encoder;
 pub mod display;
-mod error;
+pub mod error;
 mod iter;
 pub mod parse;
 #[cfg(feature = "serde")]
@@ -64,8 +64,9 @@ pub(crate) use table::Table;
 #[doc(inline)]
 pub use self::{
     display::DisplayHex,
-    iter::{BytesToHexIter, HexToBytesIter, OddLengthStringError},
-    parse::{FromHex, HexToArrayError, HexToBytesError},
+    iter::{BytesToHexIter, HexToBytesIter},
+    parse::FromHex,
+    error::{HexToVecError, HexToArrayError, InvalidCharError, InvalidLengthError, OddLengthError},
 };
 
 /// Possible case of hex.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,7 +26,8 @@ pub trait FromHex: Sized {
 
     /// Produces an object from a hex string.
     fn from_hex(s: &str) -> Result<Self, Self::Error> {
-        Self::from_byte_iter(HexToBytesIter::new(s)?)
+        let iter = HexToBytesIter::new(s).map_err(Into::into)?;
+        Self::from_byte_iter(iter)
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,54 +2,75 @@
 
 //! Hex encoding and decoding.
 
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::vec::Vec;
 use core::{fmt, str};
 
 use arrayvec::ArrayVec;
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-use crate::alloc::vec::Vec;
-use crate::error::InvalidLengthError;
+use crate::error::{InvalidLengthError, OddLengthError};
 use crate::iter::HexToBytesIter;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::{HexToBytesError, HexToArrayError};
+#[doc(inline)]
+pub use crate::error::{HexToVecError, HexToArrayError, InvalidCharError};
 
 /// Trait for objects that can be deserialized from hex strings.
 pub trait FromHex: Sized {
-    /// Error type returned while parsing hex string.
-    type Error: From<HexToBytesError> + Sized + fmt::Debug + fmt::Display;
+    /// Error type returned while constructing type from byte iterator.
+    type FromByteIterError: fmt::Debug + fmt::Display;
+
+    /// Error type returned by `from_hex`.
+    type FromHexError: From<Self::FromByteIterError> + fmt::Debug + fmt::Display;
 
     /// Produces an object from a byte iterator.
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::FromByteIterError>
     where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator;
+        I: Iterator<Item = Result<u8, InvalidCharError>> + ExactSizeIterator + DoubleEndedIterator;
 
     /// Produces an object from a hex string.
-    fn from_hex(s: &str) -> Result<Self, Self::Error> {
-        let iter = HexToBytesIter::new(s).map_err(Into::into)?;
-        Self::from_byte_iter(iter)
+    ///
+    /// Override this method if you need to do length checks on the input string (including odd
+    /// length) or if you would like to handle `0x` prefix. The default implementation does not
+    /// accept a prefix and pads with a leading '0' if the input string has odd length.
+    ///
+    /// You will get an [`InvalidCharError`] for the `x` if `s` includes a prefix.
+    fn from_hex(s: &str) -> Result<Self, Self::FromHexError> {
+        let iter = HexToBytesIter::new(s);
+        Ok(Self::from_byte_iter(iter)?)
     }
 }
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
 impl FromHex for Vec<u8> {
-    type Error = HexToBytesError;
+    type FromByteIterError = InvalidCharError;
+    type FromHexError = HexToVecError;
 
     #[inline]
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::FromByteIterError>
     where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, InvalidCharError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         iter.collect()
+    }
+
+    #[inline]
+    fn from_hex(s: &str) -> Result<Self, Self::FromHexError> {
+        if s.len() % 2 == 1 {
+            return Err(OddLengthError::new(s.len()).into());
+        }
+        let iter = HexToBytesIter::new(s);
+        Ok(Self::from_byte_iter(iter)?)
     }
 }
 
 impl<const LEN: usize> FromHex for [u8; LEN] {
-    type Error = HexToArrayError;
+    type FromByteIterError = HexToArrayError;
+    type FromHexError = HexToArrayError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::FromByteIterError>
     where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
+        I: Iterator<Item = Result<u8, InvalidCharError>> + ExactSizeIterator + DoubleEndedIterator,
     {
         if iter.len() == LEN {
             let mut ret = ArrayVec::<u8, LEN>::new();
@@ -60,6 +81,19 @@ impl<const LEN: usize> FromHex for [u8; LEN] {
         } else {
             Err(InvalidLengthError { expected: 2 * LEN, got: 2 * iter.len() }.into())
         }
+    }
+
+    #[inline]
+    fn from_hex(s: &str) -> Result<Self, Self::FromHexError> {
+        let expected = LEN * 2; // 2 hex characters per byte.
+
+        // We don't want to any padding so we check the length.
+        if s.len() != expected {
+            return Err(InvalidLengthError::new(s.len(), expected).into());
+        }
+
+        let iter = HexToBytesIter::new(s);
+        Self::from_byte_iter(iter)
     }
 }
 
@@ -72,17 +106,17 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn hex_error() {
-        use crate::error::{InvalidCharError, OddLengthStringError};
+        use crate::error::{InvalidCharError, InvalidLengthError, OddLengthError};
 
         let oddlen = "0123456789abcdef0";
         let badchar1 = "Z123456789abcdef";
         let badchar2 = "012Y456789abcdeb";
         let badchar3 = "«23456789abcdef";
 
-        assert_eq!(Vec::<u8>::from_hex(oddlen), Err(OddLengthStringError { len: 17 }.into()));
+        assert_eq!(Vec::<u8>::from_hex(oddlen), Err(OddLengthError::new(17).into()));
         assert_eq!(
             <[u8; 4]>::from_hex(oddlen),
-            Err(HexToBytesError::OddLengthString(OddLengthStringError { len: 17 }).into())
+            Err(HexToArrayError::InvalidLength(InvalidLengthError::new(17, 8)))
         );
         assert_eq!(Vec::<u8>::from_hex(badchar1), Err(InvalidCharError { invalid: b'Z' }.into()));
         assert_eq!(Vec::<u8>::from_hex(badchar2), Err(InvalidCharError { invalid: b'Y' }.into()));


### PR DESCRIPTION
Draft for feedback please, and also because on top of #67.

Add support to the library for parsing standard integer types u8, u16, u32, and u64.
    
Note we allow but do not enforce 0x prefix.

If this gets a concept ack we could then do `from_maybe_prefixed_hex, `from_prefixed_hex`, and `from_no_prefix_hex` for explicit handling if wanted.