### PR TITLE
Fix CI new build warnings

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -25,7 +25,7 @@
 //! assert_eq!(format!("{:0>8}", v.as_hex()), "0000abab");
 //!```
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::string::String;
 use core::borrow::Borrow;
 use core::fmt;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -66,7 +66,6 @@ impl<const LEN: usize> FromHex for [u8; LEN] {
 mod tests {
     use super::*;
     use crate::display::DisplayHex;
-    use crate::error::InvalidLengthError;
 
     #[test]
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
The nightly compiler just triggered a couple of new warnings/errors around import statements - fix them.