### PR TITLE
Kix's error cleanup

### DIFF
--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -66,12 +66,9 @@ impl FromStr for ALittleBitHexy {
 impl FromHex for ALittleBitHexy {
     type Error = HexToArrayError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
-    where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
-    {
-        // Errors if the iterator is the wrong length.
-        let data = <[u8; 32] as FromHex>::from_byte_iter(iter)?;
+    fn from_hex(s: &str) -> Result<Self, Self::Error> {
+        // Errors if the input is invalid
+        let data = <[u8; 32] as FromHex>::from_hex(s)?;
         // This is a contrived example (using x==0).
         Ok(ALittleBitHexy { data, x: 0 })
     }

--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -6,9 +6,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use hex_conservative::{
-    fmt_hex_exact, Case, DisplayHex, FromHex, HexToArrayError, HexToBytesError,
-};
+use hex_conservative::{fmt_hex_exact, Case, DisplayHex, FromHex, HexToArrayError};
 
 fn main() {
     let s = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
@@ -74,12 +72,9 @@ impl fmt::UpperHex for Hexy {
 impl FromHex for Hexy {
     type Error = HexToArrayError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
-    where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
-    {
-        // Errors if the iterator is the wrong length.
-        let a = <[u8; 32] as FromHex>::from_byte_iter(iter)?;
+    fn from_hex(s: &str) -> Result<Self, Self::Error> {
+        // Errors if the input is invalid
+        let a = <[u8; 32] as FromHex>::from_hex(s)?;
         Ok(Hexy { data: a })
     }
 }

--- a/examples/wrap_array_display_hex_trait.rs
+++ b/examples/wrap_array_display_hex_trait.rs
@@ -5,7 +5,7 @@
 //! For an example using the standard library `fmt` traits see `./wrap_array_fmt_traits.rs`.
 
 use hex_conservative::display::DisplayArray;
-use hex_conservative::{DisplayHex, FromHex, HexToArrayError, HexToBytesError};
+use hex_conservative::{DisplayHex, FromHex, HexToArrayError};
 
 fn main() {
     let hex = "00000000cafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
@@ -47,12 +47,7 @@ pub struct Wrap([u8; 32]);
 impl FromHex for Wrap {
     type Error = HexToArrayError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
-    where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
-    {
-        Ok(Self(FromHex::from_byte_iter(iter)?))
-    }
+    fn from_hex(s: &str) -> Result<Self, Self::Error> { Ok(Self(FromHex::from_hex(s)?)) }
 }
 
 /// Use `DisplayArray` to display the `Wrap` type.

--- a/src/error.rs
+++ b/src/error.rs
@@ -108,7 +108,7 @@ impl std::error::Error for OddLengthStringError {
 pub enum HexToArrayError {
     /// Non-hexadecimal character.
     InvalidChar(InvalidCharError),
-    /// Tried to parse fixed-length hash from a string with the wrong length (got, want).
+    /// Tried to parse fixed-length hash from a string with the wrong length.
     InvalidLength(InvalidLengthError),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -106,8 +106,8 @@ impl std::error::Error for OddLengthStringError {
 /// Hex decoding error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HexToArrayError {
-    /// Conversion error while parsing hex string.
-    Conversion(HexToBytesError),
+    /// Non-hexadecimal character.
+    InvalidChar(InvalidCharError),
     /// Tried to parse fixed-length hash from a string with the wrong length (got, want).
     InvalidLength(InvalidLengthError),
 }
@@ -117,10 +117,8 @@ impl fmt::Display for HexToArrayError {
         use HexToArrayError::*;
 
         match *self {
-            Conversion(ref e) =>
-                crate::write_err!(f, "conversion error, failed to create array from hex"; e),
-            InvalidLength(ref e) =>
-                write_err!(f, "invalid length, failed to create array from hex"; e),
+            InvalidChar(ref e) => crate::write_err!(f, "failed to parse hex digit"; e),
+            InvalidLength(ref e) => write_err!(f, "failed to parse hex"; e),
         }
     }
 }
@@ -131,15 +129,15 @@ impl std::error::Error for HexToArrayError {
         use HexToArrayError::*;
 
         match *self {
-            Conversion(ref e) => Some(e),
+            InvalidChar(ref e) => Some(e),
             InvalidLength(ref e) => Some(e),
         }
     }
 }
 
-impl From<HexToBytesError> for HexToArrayError {
+impl From<InvalidCharError> for HexToArrayError {
     #[inline]
-    fn from(e: HexToBytesError) -> Self { Self::Conversion(e) }
+    fn from(e: InvalidCharError) -> Self { Self::InvalidChar(e) }
 }
 
 impl From<InvalidLengthError> for HexToArrayError {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -10,10 +10,10 @@ use std::io;
 #[cfg(all(feature = "core2", not(feature = "std")))]
 use core2::io;
 
-use crate::error::{InvalidCharError, OddLengthStringError};
+use crate::error::InvalidCharError;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::HexToBytesError;
+pub use crate::error::{HexToBytesError, OddLengthStringError};
 
 /// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
 pub struct HexToBytesIter<'a> {
@@ -34,9 +34,9 @@ impl<'a> HexToBytesIter<'a> {
     ///
     /// If the input string is of odd length.
     #[inline]
-    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, HexToBytesError> {
+    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, OddLengthStringError> {
         if s.len() % 2 != 0 {
-            Err(OddLengthStringError { len: s.len() }.into())
+            Err(OddLengthStringError { len: s.len() })
         } else {
             Ok(HexToBytesIter { iter: s.bytes() })
         }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -11,10 +11,7 @@ use std::io;
 #[cfg(all(feature = "core2", not(feature = "std")))]
 use core2::io;
 
-use crate::error::InvalidCharError;
-
-#[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::OddLengthStringError;
+use crate::error::{InvalidCharError, OddLengthStringError};
 
 /// Convenience alias for `HexToBytesIter<HexDigitsIter<'a>>`.
 pub type HexSliceToBytesIter<'a> = HexToBytesIter<HexDigitsIter<'a>>;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -2,6 +2,7 @@
 
 //! Iterator that converts hex to bytes.
 
+use core::convert::TryInto;
 use core::iter::FusedIterator;
 use core::str;
 #[cfg(feature = "std")]
@@ -15,41 +16,46 @@ use crate::error::InvalidCharError;
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use crate::error::OddLengthStringError;
 
-/// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
-pub struct HexToBytesIter<'a> {
-    /// The [`Bytes`] iterator whose next two bytes will be decoded to yield the next byte.
-    ///
-    /// # Invariants
-    ///
-    /// `iter` is guaranteed to be of even length.
-    ///
-    /// [`Bytes`]: core::str::Bytes
-    iter: str::Bytes<'a>,
+/// Convenience alias for `HexToBytesIter<HexDigitsIter<'a>>`.
+pub type HexSliceToBytesIter<'a> = HexToBytesIter<HexDigitsIter<'a>>;
+
+/// Iterator yielding bytes decoded from an iterator of pairs of hex digits.
+pub struct HexToBytesIter<T: Iterator<Item = [u8; 2]>> {
+    iter: T,
 }
 
-impl<'a> HexToBytesIter<'a> {
+impl<'a> HexToBytesIter<HexDigitsIter<'a>> {
     /// Constructs a new `HexToBytesIter` from a string slice.
     ///
     /// # Errors
     ///
     /// If the input string is of odd length.
     #[inline]
-    pub fn new(s: &'a str) -> Result<HexToBytesIter<'a>, OddLengthStringError> {
+    pub fn new(s: &'a str) -> Result<Self, OddLengthStringError> {
         if s.len() % 2 != 0 {
             Err(OddLengthStringError { len: s.len() })
         } else {
-            Ok(HexToBytesIter { iter: s.bytes() })
+            Ok(Self::new_unchecked(s))
         }
+    }
+
+    pub(crate) fn new_unchecked(s: &'a str) -> Self {
+        Self::from_pairs(HexDigitsIter::new_unchecked(s.as_bytes()))
     }
 }
 
-impl<'a> Iterator for HexToBytesIter<'a> {
+impl<T: Iterator<Item = [u8; 2]>> HexToBytesIter<T> {
+    /// Constructs a custom hex decoding iterator from another iterator.
+    #[inline]
+    pub fn from_pairs(iter: T) -> Self { Self { iter } }
+}
+
+impl<T: Iterator<Item = [u8; 2]>> Iterator for HexToBytesIter<T> {
     type Item = Result<u8, InvalidCharError>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let hi = self.iter.next()?;
-        let lo = self.iter.next().expect("iter length invariant violated, this is a bug");
+        let [hi, lo] = self.iter.next()?;
         Some(hex_chars_to_byte(hi, lo))
     }
 
@@ -58,26 +64,34 @@ impl<'a> Iterator for HexToBytesIter<'a> {
         let (min, max) = self.iter.size_hint();
         (min / 2, max.map(|x| x / 2))
     }
-}
 
-impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
     #[inline]
-    fn next_back(&mut self) -> Option<Self::Item> {
-        let lo = self.iter.next_back()?;
-        let hi = self.iter.next_back().expect("iter length invariant violated, this is a bug");
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let [hi, lo] = self.iter.nth(n)?;
         Some(hex_chars_to_byte(hi, lo))
     }
 }
 
-impl<'a> ExactSizeIterator for HexToBytesIter<'a> {
+impl<T: Iterator<Item = [u8; 2]> + DoubleEndedIterator> DoubleEndedIterator for HexToBytesIter<T> {
     #[inline]
-    fn len(&self) -> usize { self.iter.len() / 2 }
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let [hi, lo] = self.iter.next_back()?;
+        Some(hex_chars_to_byte(hi, lo))
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        let [hi, lo] = self.iter.nth_back(n)?;
+        Some(hex_chars_to_byte(hi, lo))
+    }
 }
 
-impl<'a> FusedIterator for HexToBytesIter<'a> {}
+impl<T: Iterator<Item = [u8; 2]> + ExactSizeIterator> ExactSizeIterator for HexToBytesIter<T> {}
+
+impl<T: Iterator<Item = [u8; 2]> + FusedIterator> FusedIterator for HexToBytesIter<T> {}
 
 #[cfg(any(feature = "std", feature = "core2"))]
-impl<'a> io::Read for HexToBytesIter<'a> {
+impl<T: Iterator<Item = [u8; 2]> + FusedIterator> io::Read for HexToBytesIter<T> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut bytes_read = 0usize;
@@ -93,6 +107,56 @@ impl<'a> io::Read for HexToBytesIter<'a> {
         Ok(bytes_read)
     }
 }
+
+/// An internal iterator returning hex digits from a string.
+///
+/// Generally you shouldn't need to refer to this or bother with it and just use
+/// [`HexToBytesIter::new`] consuming the returned value and use `HexSliceToBytesIter` if you need
+/// to refer to the iterator in your types.
+pub struct HexDigitsIter<'a> {
+    // Invariant: the length of the chunks is 2.
+    // Technically, this is `iter::Map` but we can't use it because fn is anonymous.
+    // We can swap this for actual `ArrayChunks` once it's stable.
+    iter: core::slice::ChunksExact<'a, u8>,
+}
+
+impl<'a> HexDigitsIter<'a> {
+    #[inline]
+    fn new_unchecked(digits: &'a [u8]) -> Self { Self { iter: digits.chunks_exact(2) } }
+}
+
+impl<'a> Iterator for HexDigitsIter<'a> {
+    type Item = [u8; 2];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|digits| digits.try_into().expect("HexDigitsIter invariant"))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|digits| digits.try_into().expect("HexDigitsIter invariant"))
+    }
+}
+
+impl<'a> DoubleEndedIterator for HexDigitsIter<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|digits| digits.try_into().expect("HexDigitsIter invariant"))
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth_back(n).map(|digits| digits.try_into().expect("HexDigitsIter invariant"))
+    }
+}
+
+impl<'a> ExactSizeIterator for HexDigitsIter<'a> {}
+
+impl<'a> core::iter::FusedIterator for HexDigitsIter<'a> {}
 
 /// `hi` and `lo` are bytes representing hex characters.
 fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, InvalidCharError> {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,7 +13,7 @@ use core2::io;
 use crate::error::InvalidCharError;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::{HexToBytesError, OddLengthStringError};
+pub use crate::error::OddLengthStringError;
 
 /// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
 pub struct HexToBytesIter<'a> {
@@ -44,10 +44,10 @@ impl<'a> HexToBytesIter<'a> {
 }
 
 impl<'a> Iterator for HexToBytesIter<'a> {
-    type Item = Result<u8, HexToBytesError>;
+    type Item = Result<u8, InvalidCharError>;
 
     #[inline]
-    fn next(&mut self) -> Option<Result<u8, HexToBytesError>> {
+    fn next(&mut self) -> Option<Self::Item> {
         let hi = self.iter.next()?;
         let lo = self.iter.next().expect("iter length invariant violated, this is a bug");
         Some(hex_chars_to_byte(hi, lo))
@@ -62,7 +62,7 @@ impl<'a> Iterator for HexToBytesIter<'a> {
 
 impl<'a> DoubleEndedIterator for HexToBytesIter<'a> {
     #[inline]
-    fn next_back(&mut self) -> Option<Result<u8, HexToBytesError>> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         let lo = self.iter.next_back()?;
         let hi = self.iter.next_back().expect("iter length invariant violated, this is a bug");
         Some(hex_chars_to_byte(hi, lo))
@@ -95,7 +95,7 @@ impl<'a> io::Read for HexToBytesIter<'a> {
 }
 
 /// `hi` and `lo` are bytes representing hex characters.
-fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, HexToBytesError> {
+fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, InvalidCharError> {
     let hih = (hi as char).to_digit(16).ok_or(InvalidCharError { invalid: hi })?;
     let loh = (lo as char).to_digit(16).ok_or(InvalidCharError { invalid: lo })?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) use table::Table;
 #[doc(inline)]
 pub use self::{
     display::DisplayHex,
-    iter::{BytesToHexIter, HexToBytesIter},
+    iter::{BytesToHexIter, HexToBytesIter, OddLengthStringError},
     parse::{FromHex, HexToArrayError, HexToBytesError},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,9 @@ pub(crate) use table::Table;
 #[doc(inline)]
 pub use self::{
     display::DisplayHex,
-    iter::{BytesToHexIter, HexToBytesIter, HexSliceToBytesIter, OddLengthStringError},
-    parse::{FromHex, HexToArrayError, HexToBytesError},
+    error::{OddLengthStringError, HexToBytesError, HexToArrayError},
+    iter::{BytesToHexIter, HexToBytesIter, HexSliceToBytesIter},
+    parse::FromHex,
 };
 
 /// Possible case of hex.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) use table::Table;
 #[doc(inline)]
 pub use self::{
     display::DisplayHex,
-    iter::{BytesToHexIter, HexToBytesIter, OddLengthStringError},
+    iter::{BytesToHexIter, HexToBytesIter, HexSliceToBytesIter, OddLengthStringError},
     parse::{FromHex, HexToArrayError, HexToBytesError},
 };
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,7 +26,8 @@ pub trait FromHex: Sized {
 
     /// Produces an object from a hex string.
     fn from_hex(s: &str) -> Result<Self, Self::Error> {
-        Self::from_byte_iter(HexToBytesIter::new(s)?)
+        let iter = HexToBytesIter::new(s).map_err(Into::into)?;
+        Self::from_byte_iter(iter)
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -17,48 +17,33 @@ pub use crate::error::{HexToBytesError, HexToArrayError};
 /// Trait for objects that can be deserialized from hex strings.
 pub trait FromHex: Sized {
     /// Error type returned while parsing hex string.
-    type Error: From<HexToBytesError> + Sized + fmt::Debug + fmt::Display;
-
-    /// Produces an object from a byte iterator.
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
-    where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator;
+    type Error: Sized + fmt::Debug + fmt::Display;
 
     /// Produces an object from a hex string.
-    fn from_hex(s: &str) -> Result<Self, Self::Error> {
-        let iter = HexToBytesIter::new(s).map_err(Into::into)?;
-        Self::from_byte_iter(iter)
-    }
+    fn from_hex(s: &str) -> Result<Self, Self::Error>;
 }
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
 impl FromHex for Vec<u8> {
     type Error = HexToBytesError;
 
-    #[inline]
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
-    where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
-    {
-        iter.collect()
+    fn from_hex(s: &str) -> Result<Self, Self::Error> {
+        HexToBytesIter::new(s)?.map(|result| result.map_err(Into::into)).collect()
     }
 }
 
 impl<const LEN: usize> FromHex for [u8; LEN] {
     type Error = HexToArrayError;
 
-    fn from_byte_iter<I>(iter: I) -> Result<Self, Self::Error>
-    where
-        I: Iterator<Item = Result<u8, HexToBytesError>> + ExactSizeIterator + DoubleEndedIterator,
-    {
-        if iter.len() == LEN {
+    fn from_hex(s: &str) -> Result<Self, Self::Error> {
+        if s.len() == LEN * 2 {
             let mut ret = ArrayVec::<u8, LEN>::new();
-            for byte in iter {
+            for byte in HexToBytesIter::new(s).expect("length checked above") {
                 ret.push(byte?);
             }
             Ok(ret.into_inner().expect("inner is full"))
         } else {
-            Err(InvalidLengthError { expected: 2 * LEN, got: 2 * iter.len() }.into())
+            Err(InvalidLengthError { expected: 2 * LEN, got: s.len() }.into())
         }
     }
 }
@@ -81,7 +66,7 @@ mod tests {
         assert_eq!(Vec::<u8>::from_hex(oddlen), Err(OddLengthStringError { len: 17 }.into()));
         assert_eq!(
             <[u8; 4]>::from_hex(oddlen),
-            Err(HexToBytesError::OddLengthString(OddLengthStringError { len: 17 }).into())
+            Err(InvalidLengthError { got: 17, expected: 8 }.into())
         );
         assert_eq!(Vec::<u8>::from_hex(badchar1), Err(InvalidCharError { invalid: b'Z' }.into()));
         assert_eq!(Vec::<u8>::from_hex(badchar2), Err(InvalidCharError { invalid: b'Y' }.into()));

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -38,7 +38,8 @@ impl<const LEN: usize> FromHex for [u8; LEN] {
     fn from_hex(s: &str) -> Result<Self, Self::Error> {
         if s.len() == LEN * 2 {
             let mut ret = ArrayVec::<u8, LEN>::new();
-            for byte in HexToBytesIter::new(s).expect("length checked above") {
+            // checked above
+            for byte in HexToBytesIter::new_unchecked(s) {
                 ret.push(byte?);
             }
             Ok(ret.into_inner().expect("inner is full"))


### PR DESCRIPTION
This is #75, rebased on master with 61baef84c1b1c82e7027c091fe35a00f9a209271 removed. Absolutely no other changes.

Everything has come to a grinding halt in `rust-bitcoin` because of the `hex` crate, and this error stuff is the main problem. If Kix does not rebase before you wake up tomorrow Andrew can you please one-ack-merge this so we can get on and release the `hex` crate. (Implicitly its two acks anyways because I acked by pushing it up and one can diff against #75 to see no changes.)

Kix, I don't mean to stress you I just want to make some forward progress please.