### PR TITLE
Make `fmt_hex_exact` honour precision

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -420,8 +420,9 @@ mod tests {
                     fmt_hex_exact!(f, 32, &self.0, Case::Lower)
                 }
             }
-
-            assert_eq!(Dummy([42; 32]).to_string(), "2a".repeat(32));
+            let dummy = Dummy([42; 32]);
+            assert_eq!(dummy.to_string(), "2a".repeat(32));
+            assert_eq!(format!("{:.10}", dummy), "2a".repeat(5));
         }
 
         #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -344,6 +344,10 @@ macro_rules! fmt_hex_exact {
 pub use fmt_hex_exact;
 
 // Implementation detail of `write_hex_exact` macro to de-duplicate the code
+//
+// Whether hex is an integer or a string is debatable, we cater a little bit to each.
+// - We support users adding `0x` prefix using "{:#}" (treating hex like an integer).
+// - We support limiting the output using precision "{:.10}" (treating hex like a string).
 #[doc(hidden)]
 #[inline]
 pub fn fmt_hex_exact_fn<I, const N: usize>(
@@ -357,7 +361,14 @@ where
 {
     let mut encoder = BufEncoder::<N>::new();
     encoder.put_bytes(bytes, case);
-    f.pad_integral(true, "0x", encoder.as_str())
+    let encoded = encoder.as_str();
+
+    if let Some(precision) = f.precision() {
+        if encoded.len() > precision {
+            return f.pad_integral(true, "0x", &encoded[..precision]);
+        }
+    }
+    f.pad_integral(true, "0x", encoded)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This one was interesting, we wanted the following test to pass in `rust-bitcoin`:
```rust
    #[test]
    fn txid_truncates() {
        let txid = Txid::from_str("a6eab3c14ab5272a58a5ba91505ba1a4b6d7a3a9fcbd187b6cd99a7b6d548cb7").unwrap();
        let want = "a6eab3c14a";
        let got = format!("{:10}", txid);
        assert_eq!(got, want);
    }
```

Turns out that that actually should not pass, we should be using "{:.10}", you can verify by using
```rust
            println!("{:2}", 123456);
            println!("{:.2}", 123456);
            println!("{:2}", "123456");
            println!("{:.2}", "123456");
```
which outputs:
```
123456
123456
123456
12
```

If we want to behave the same as stdlib then we should honour precision (the "{:.2}" one).

Another interesting sidenote, hashes are kind of integers and kind of strings - we support using "{:#}" to add `0x` (treating hash like an integer) and we want to support precision, treating hash like a string.

Patch 2 is a unit test that fails if put first.   
 