### PR TITLE
Fix arrayvec minimal version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ std = ["alloc"]
 alloc = []
 
 [dependencies]
-arrayvec = { version = "0.7", default-features = false }
+arrayvec = { version = "0.7.2", default-features = false }
 core2 = { version = "0.3.2", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 


### PR DESCRIPTION
The ArrayString<CAP>::remaining_capacity method was introduced in arrayvec@0.7.2:

https://github.com/bluss/arrayvec/commit/481f93084eecebda0445cb7f81b40b9789dd1559

This causes `cargo build -Z minimal-versions' to fail when building hex-conservative.

* Cargo.toml (dependencies) <arrayvec>: Update to 0.7.2.