### PR TITLE
Fix order of 'got' and 'want' fields when populating InvalidLength error

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -85,7 +85,9 @@ macro_rules! impl_fromhex_array {
                     }
                     Ok(ret)
                 } else {
-                    Err(HexToArrayError::InvalidLength(2 * $len, 2 * iter.len()))
+                    let got = 2 * iter.len();
+                    let want = 2 * $len;
+                    Err(HexToArrayError::InvalidLength(got, want))
                 }
             }
         }
@@ -183,7 +185,9 @@ mod tests {
     fn hex_to_array_error() {
         use HexToArrayError::*;
         let len_sixteen = "0123456789abcdef";
-        assert_eq!(<[u8; 4]>::from_hex(len_sixteen), Err(InvalidLength(8, 16)));
+        let result = <[u8; 4]>::from_hex(len_sixteen);
+        assert_eq!(result, Err(InvalidLength(16, 8)));
+        assert_eq!(&result.unwrap_err().to_string(), "bad hex string length 16 (expected 8)");
     }
 
     #[test]


### PR DESCRIPTION
Error `HexToArrayError::InvalidLength` has two numeric fields 'got' and 'want' (in this order), however the two fields were populated in the opposite order. This patch fixes it and thus fixes #87.

To crosscheck the order of fields:

https://github.com/rust-bitcoin/hex-conservative/blob/bd9c2c7b44bc89e91ec6bb4f7164672e27a43f64/src/parse.rs#L115-L122