### PR TITLE
Release tracking PR: `v0.1.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2 - 2024-05-14
+
+- Fix bug in output of `InvalidError` [#88](https://github.com/rust-bitcoin/hex-conservative/pull/88).
+
 # 0.1.1 - 2023-07-19
 
 - [Add `test_hex_unwrap`](https://github.com/rust-bitcoin/hex-conservative/pull/24) hex parsing macro for test usage.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.1.1" }
+hex = { path = "..", package = "hex-conservative" }
 
 [[bin]]
 name = "hex"


### PR DESCRIPTION
Two patches in preparation for doing a point release to release the bug fix in #88.

- Patch 1: Remove the version number from `fuzz` manifest.
- Patch 2: Add changelog and bump version. 