### PR TITLE
Add `impl_fmt_traits` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,14 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[doc(hidden)]
+pub mod _export {
+    /// A re-export of core::*
+    pub mod _core {
+        pub use core::*;
+    }
+}
+
 pub mod buf_encoder;
 pub mod display;
 pub mod error;


### PR DESCRIPTION
Add a macro that implements the `fmt::{LowerHex, UpperHex, Display, Debug}` traits. Includes support for displaying backwards.

### Context

In `bitcoin_hashes` we have _two_ versions of this code, moving it here is better because it is  general hex related code. Note however that the reason for supporting display backwards might see strange unusual to the casual reader.

## Note

Note please the use of naked `core::foo` in the macro requiring `core` to be in scope, is this reasonable of should we do the ugly re-export stuff we do in `bitcoin_hashes`: `$crate::_export::_core::foo`?