### PR TITLE
Release tracking PR: `v0.2.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.1 - 2024-05-17
+
+- Add a new `impl_fmt_traits` macro that can be used to implement `fmt::{LowerHex, UpperHex,
+  Display, Debug}` [#90](https://github.com/rust-bitcoin/hex-conservative/pull/90)
+
 # 0.2.0 - 2024-02-27
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.2.0" }
+hex = { path = "..", package = "hex-conservative" }
 
 [[bin]]
 name = "hex"

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -21,7 +21,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-hex = { path = "..", package = "hex-conservative", version = "0.2.0" }
+hex = { path = "..", package = "hex-conservative" }
 EOF
 
 for targetFile in $(listTargetFiles); do


### PR DESCRIPTION
In preparation for release add a changelog entry and bump the version number to `v0.2.1`.

Note: Includes an initial patch to remove explicit version of `hex` from the fuzz crate.
