### PR TITLE
fuzz: Add unexpected_cfgs to manifest

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,3 +19,6 @@ path = "fuzz_targets/hex.rs"
 [[bin]]
 name = "encode"
 path = "fuzz_targets/encode.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)'] }


### PR DESCRIPTION
Quiet the new lint by adding an unexpected cfgs for `fuzzing`.