### PR TITLE
Remove `core2` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ members = ["fuzz"]
 
 [features]
 default = ["std"]
-std = ["alloc"]
-alloc = []
+std = ["alloc", "bitcoin-io?/std"]
+alloc = ["bitcoin-io?/alloc"]
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
-core2 = { version = "0.3.2", default-features = false, optional = true }
+bitcoin-io = { version = "0.1.2", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
 


### PR DESCRIPTION
We use `core2` to implement `Read` because it needs the `io::Error`. Now that we have `bitcoin-io` we can implement `Read` from there and not provide the `core2` impl.

- Remove optional `core2` dependency.
- Add an optional dependency on `bitcoin-io`.