### PR TITLE
Remove the core2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ alloc = []
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
-core2 = { version = "0.3.2", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="std alloc core2 serde"
+FEATURES="std alloc serde"
 MSRV="1\.48\.0"
 
 cargo --version

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -8,9 +8,6 @@ use core::str;
 #[cfg(feature = "std")]
 use std::io;
 
-#[cfg(all(feature = "core2", not(feature = "std")))]
-use core2::io;
-
 use crate::error::{InvalidCharError, OddLengthStringError};
 
 /// Convenience alias for `HexToBytesIter<HexDigitsIter<'a>>`.
@@ -87,7 +84,7 @@ impl<T: Iterator<Item = [u8; 2]> + ExactSizeIterator> ExactSizeIterator for HexT
 
 impl<T: Iterator<Item = [u8; 2]> + FusedIterator> FusedIterator for HexToBytesIter<T> {}
 
-#[cfg(any(feature = "std", feature = "core2"))]
+#[cfg(feature = "std")]
 impl<T: Iterator<Item = [u8; 2]> + FusedIterator> io::Read for HexToBytesIter<T> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {


### PR DESCRIPTION
We would like to stabalise this library but the `core2` dependency is unstable. Lets just remove it.