### PR TITLE
Encoding improvements

### DIFF
--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -38,7 +38,10 @@ impl<const CAP: usize> BufEncoder<CAP> {
     #[inline]
     #[track_caller]
     pub fn put_byte(&mut self, byte: u8, case: Case) {
-        self.buf.push_str(&case.table().byte_to_hex(byte));
+        let byte = case.table().byte_to_hex(byte);
+        // SAFETY: Table::byte_to_hex returns only valid ASCII
+        let byte = unsafe { core::str::from_utf8_unchecked(&byte) };
+        self.buf.push_str(byte);
     }
 
     /// Encodes `bytes` as hex in given `case` and appends them to the buffer.

--- a/src/display.rs
+++ b/src/display.rs
@@ -152,7 +152,7 @@ fn internal_display(bytes: &[u8], f: &mut fmt::Formatter, case: Case) -> fmt::Re
         Some(max) if bytes.len() > max / 2 => {
             write!(f, "{}", bytes[..(max / 2)].as_hex())?;
             if max % 2 == 1 {
-                f.write_char(case.table().byte_to_hex(bytes[max / 2]).as_bytes()[0].into())?;
+                f.write_char(case.table().byte_to_hex(bytes[max / 2])[0] as char)?;
             }
         }
         Some(_) | None => {

--- a/src/display.rs
+++ b/src/display.rs
@@ -115,7 +115,7 @@ fn internal_display(bytes: &[u8], f: &mut fmt::Formatter, case: Case) -> fmt::Re
     //
     // This would complicate the code so I was too lazy to do them but feel free to send a PR!
 
-    let mut encoder = BufEncoder::<1024>::new();
+    let mut encoder = BufEncoder::<1024>::new(case);
 
     let pad_right = if let Some(width) = f.width() {
         let string_len = match f.precision() {
@@ -158,11 +158,11 @@ fn internal_display(bytes: &[u8], f: &mut fmt::Formatter, case: Case) -> fmt::Re
         Some(_) | None => {
             let mut chunks = bytes.chunks_exact(512);
             for chunk in &mut chunks {
-                encoder.put_bytes(chunk, case);
+                encoder.put_bytes(chunk);
                 f.write_str(encoder.as_str())?;
                 encoder.clear();
             }
-            encoder.put_bytes(chunks.remainder(), case);
+            encoder.put_bytes(chunks.remainder());
             f.write_str(encoder.as_str())?;
         }
     }
@@ -522,15 +522,15 @@ where
     I: IntoIterator,
     I::Item: Borrow<u8>,
 {
-    let mut encoder = BufEncoder::<N>::new();
+    let mut encoder = BufEncoder::<N>::new(case);
     let encoded = match f.precision() {
         Some(p) if p < N => {
             let n = (p + 1) / 2;
-            encoder.put_bytes(bytes.into_iter().take(n), case);
+            encoder.put_bytes(bytes.into_iter().take(n));
             &encoder.as_str()[..p]
         }
         _ => {
-            encoder.put_bytes(bytes, case);
+            encoder.put_bytes(bytes);
             encoder.as_str()
         }
     };

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -9,6 +9,7 @@ use core::str;
 use std::io;
 
 use crate::error::{InvalidCharError, OddLengthStringError};
+use crate::Table;
 
 /// Convenience alias for `HexToBytesIter<HexDigitsIter<'a>>`.
 pub type HexSliceToBytesIter<'a> = HexToBytesIter<HexDigitsIter<'a>>;
@@ -197,6 +198,8 @@ pub struct BytesToHexIter<I: Iterator<Item = u8>> {
     iter: I,
     /// The low character of the pair (high, low) of hex characters encoded per byte.
     low: Option<char>,
+    /// The byte-to-hex conversion table.
+    table: &'static Table,
 }
 
 impl<I> BytesToHexIter<I>
@@ -204,7 +207,7 @@ where
     I: Iterator<Item = u8>,
 {
     /// Constructs a new `BytesToHexIter` from a byte iterator.
-    pub fn new(iter: I) -> BytesToHexIter<I> { Self { iter, low: None } }
+    pub fn new(iter: I) -> BytesToHexIter<I> { Self { iter, low: None, table: &Table::LOWER } }
 }
 
 impl<I> Iterator for BytesToHexIter<I>
@@ -221,9 +224,9 @@ where
                 Some(c)
             }
             None => self.iter.next().map(|b| {
-                let (high, low) = byte_to_hex_chars(b);
-                self.low = Some(low);
-                high
+                let [high, low] = self.table.byte_to_hex(b);
+                self.low = Some(low as char);
+                high as char
             }),
         }
     }
@@ -250,9 +253,9 @@ where
                 Some(c)
             }
             None => self.iter.next_back().map(|b| {
-                let (high, low) = byte_to_hex_chars(b);
-                self.low = Some(low);
-                high
+                let [high, low] = self.table.byte_to_hex(b);
+                self.low = Some(low as char);
+                high as char
             }),
         }
     }
@@ -268,31 +271,21 @@ where
 
 impl<I> FusedIterator for BytesToHexIter<I> where I: FusedIterator + Iterator<Item = u8> {}
 
-/// Returns the (high, low) hex characters encoding `b`.
-fn byte_to_hex_chars(b: u8) -> (char, char) {
-    const HEX_TABLE: [u8; 16] = *b"0123456789abcdef";
-
-    let high = HEX_TABLE[usize::from(b >> 4)];
-    let low = HEX_TABLE[usize::from(b & 0b00001111)];
-
-    (char::from(high), char::from(low))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn encode_byte() {
-        let tcs =
-            vec![(0x00, ('0', '0')), (0x0a, ('0', 'a')), (0xad, ('a', 'd')), (0xff, ('f', 'f'))];
-        for (b, (high, low)) in tcs {
-            assert_eq!(byte_to_hex_chars(b), (high, low));
-        }
-        assert_eq!(byte_to_hex_chars(0x00), ('0', '0'));
-        assert_eq!(byte_to_hex_chars(0x0a), ('0', 'a'));
-        assert_eq!(byte_to_hex_chars(0xad), ('a', 'd'));
-        assert_eq!(byte_to_hex_chars(0xff), ('f', 'f'));
+        assert_eq!(Table::LOWER.byte_to_hex(0x00), [b'0', b'0']);
+        assert_eq!(Table::LOWER.byte_to_hex(0x0a), [b'0', b'a']);
+        assert_eq!(Table::LOWER.byte_to_hex(0xad), [b'a', b'd']);
+        assert_eq!(Table::LOWER.byte_to_hex(0xff), [b'f', b'f']);
+
+        assert_eq!(Table::UPPER.byte_to_hex(0x00), [b'0', b'0']);
+        assert_eq!(Table::UPPER.byte_to_hex(0x0a), [b'0', b'A']);
+        assert_eq!(Table::UPPER.byte_to_hex(0xad), [b'A', b'D']);
+        assert_eq!(Table::UPPER.byte_to_hex(0xff), [b'F', b'F']);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,6 @@ impl Case {
 
 /// Correctness boundary for `Table`.
 mod table {
-    use arrayvec::ArrayString;
-
     /// Table of hex chars.
     //
     // Correctness invariant: each byte in the table must be ASCII.
@@ -130,12 +128,14 @@ mod table {
         /// Encodes single byte as two ASCII chars using the given table.
         ///
         /// The function guarantees only returning values from the provided table.
+        ///
+        /// The function returns a `[u8; 2]` to give callers the freedom to interpret the return
+        /// value as a `&str` via `str::from_utf8` or a collection of `char`'s.
         #[inline]
-        pub(crate) fn byte_to_hex(&self, byte: u8) -> ArrayString<2> {
+        pub(crate) fn byte_to_hex(&self, byte: u8) -> [u8; 2] {
             let left = self.0[usize::from(byte.wrapping_shr(4))];
             let right = self.0[usize::from(byte & 0x0F)];
-
-            ArrayString::from_byte_string(&[left, right]).expect("Table only contains valid ASCII")
+            [left, right]
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,8 @@ mod table {
         /// value as a `&str` via `str::from_utf8` or a collection of `char`'s.
         #[inline]
         pub(crate) fn byte_to_hex(&self, byte: u8) -> [u8; 2] {
-            let left = self.0[usize::from(byte.wrapping_shr(4))];
-            let right = self.0[usize::from(byte & 0x0F)];
+            let left = self.0[(byte >> 4) as usize];
+            let right = self.0[(byte & 0x0F) as usize];
             [left, right]
         }
     }


### PR DESCRIPTION
Miscellaneous collection of  improvements to hex encoding, please see the commit messages for further details:
- (API Break) `BytesToHexIter` can now yield uppercase characters.
- (API Break) `BufEncoder` now enforces uniform case hex encoding.
- Performance improvements to `DisplayHex` and `BytesToHexIter`.