### PR TITLE
Encoding performance improvements

### DIFF
--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -38,7 +38,10 @@ impl<const CAP: usize> BufEncoder<CAP> {
     #[inline]
     #[track_caller]
     pub fn put_byte(&mut self, byte: u8, case: Case) {
-        self.buf.push_str(&case.table().byte_to_hex(byte));
+        let hex_chars: [u8; 2] = case.table().byte_to_hex(byte);
+        // SAFETY: Table::byte_to_hex returns only valid ASCII
+        let hex_str = unsafe { core::str::from_utf8_unchecked(&hex_chars) };
+        self.buf.push_str(hex_str);
     }
 
     /// Encodes `bytes` as hex in given `case` and appends them to the buffer.

--- a/src/display.rs
+++ b/src/display.rs
@@ -152,7 +152,7 @@ fn internal_display(bytes: &[u8], f: &mut fmt::Formatter, case: Case) -> fmt::Re
         Some(max) if bytes.len() > max / 2 => {
             write!(f, "{}", bytes[..(max / 2)].as_hex())?;
             if max % 2 == 1 {
-                f.write_char(case.table().byte_to_hex(bytes[max / 2]).as_bytes()[0].into())?;
+                f.write_char(char::from(case.table().byte_to_hex(bytes[max / 2])[0]))?;
             }
         }
         Some(_) | None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,6 @@ impl Case {
 
 /// Correctness boundary for `Table`.
 mod table {
-    use arrayvec::ArrayString;
-
     /// Table of hex chars.
     //
     // Correctness invariant: each byte in the table must be ASCII.
@@ -130,12 +128,14 @@ mod table {
         /// Encodes single byte as two ASCII chars using the given table.
         ///
         /// The function guarantees only returning values from the provided table.
+        ///
+        /// The function returns a `[u8; 2]` to give callers the freedom to interpret the return
+        /// value as a `&str` via `str::from_utf8` or a collection of `char`'s.
         #[inline]
-        pub(crate) fn byte_to_hex(&self, byte: u8) -> ArrayString<2> {
-            let left = self.0[usize::from(byte.wrapping_shr(4))];
+        pub(crate) fn byte_to_hex(&self, byte: u8) -> [u8; 2] {
+            let left = self.0[usize::from(byte >> 4)];
             let right = self.0[usize::from(byte & 0x0F)];
-
-            ArrayString::from_byte_string(&[left, right]).expect("Table only contains valid ASCII")
+            [left, right]
         }
     }
 }


### PR DESCRIPTION
Make significant performance improvements to `BytesToHexIter` and `DisplayHex`, see individual commits for details on the exact performance improvements.

Also deletes `fn byte_to_hex_chars` as it repeats the functionality offered by `Table::byte_to_hex`.