### PR TITLE
Align `fmt_hex_exact` and `Display` impls

### DIFF
--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -90,7 +90,7 @@ impl<const CAP: usize> BufEncoder<CAP> {
 
     /// Returns true if no more bytes can be written into the buffer.
     #[inline]
-    pub fn is_full(&self) -> bool { self.space_remaining() == 0 }
+    pub fn is_full(&self) -> bool { self.buf.is_full() }
 
     /// Returns the written bytes as a hex `str`.
     #[inline]

--- a/src/display.rs
+++ b/src/display.rs
@@ -543,6 +543,12 @@ where
     I: IntoIterator,
     I::Item: Borrow<u8>,
 {
+    let mut padding_encoder = BufEncoder::<1024>::new(case);
+    let pad_right = write_pad_left(f, N / 2, &mut padding_encoder)?;
+
+    if f.alternate() {
+        f.write_str("0x")?;
+    }
     let mut encoder = BufEncoder::<N>::new(case);
     let encoded = match f.precision() {
         Some(p) if p < N => {
@@ -555,7 +561,9 @@ where
             encoder.as_str()
         }
     };
-    f.pad_integral(true, "0x", encoded)
+    f.write_str(encoded)?;
+
+    write_pad_right(f, pad_right, &mut padding_encoder)
 }
 
 /// Given a `T:` [`fmt::Write`], `HexWriter` implements [`std::io::Write`]

--- a/src/display.rs
+++ b/src/display.rs
@@ -674,6 +674,12 @@ mod tests {
         }
 
         #[test]
+        fn alternate_flag() {
+            test_display_hex!("{:#?}", [0xc0, 0xde, 0xca, 0xfe], "0xc0decafe");
+            test_display_hex!("{:#}", [0xc0, 0xde, 0xca, 0xfe], "0xc0decafe");
+        }
+
+        #[test]
         fn display_short_with_padding() {
             test_display_hex!("Hello {:<8}!", [0xbe, 0xef], "Hello beef    !");
             test_display_hex!("Hello {:-<8}!", [0xbe, 0xef], "Hello beef----!");

--- a/src/display.rs
+++ b/src/display.rs
@@ -704,6 +704,7 @@ mod tests {
         #[test]
         fn alternate_flag() {
             define_dummy!(4);
+
             test_display_hex!("{:#?}", [0xc0, 0xde, 0xca, 0xfe], "0xc0decafe");
             test_display_hex!("{:#}", [0xc0, 0xde, 0xca, 0xfe], "0xc0decafe");
         }
@@ -711,20 +712,32 @@ mod tests {
         #[test]
         fn display_short_with_padding() {
             define_dummy!(2);
+
             test_display_hex!("Hello {:<8}!", [0xbe, 0xef], "Hello beef    !");
             test_display_hex!("Hello {:-<8}!", [0xbe, 0xef], "Hello beef----!");
             test_display_hex!("Hello {:^8}!", [0xbe, 0xef], "Hello   beef  !");
             test_display_hex!("Hello {:>8}!", [0xbe, 0xef], "Hello     beef!");
+
+            test_display_hex!("Hello {:<#8}!", [0xbe, 0xef], "Hello 0xbeef  !");
+            test_display_hex!("Hello {:-<#8}!", [0xbe, 0xef], "Hello 0xbeef--!");
+            test_display_hex!("Hello {:^#8}!", [0xbe, 0xef], "Hello  0xbeef !");
+            test_display_hex!("Hello {:>#8}!", [0xbe, 0xef], "Hello   0xbeef!");
         }
 
         #[test]
         fn display_long() {
+            define_dummy!(512);
             // Note this string is shorter than the one above.
             let a = [0xab; 512];
+
             let mut want = "0".repeat(2000 - 1024);
             want.extend(core::iter::repeat("ab").take(512));
-            define_dummy!(512);
             test_display_hex!("{:0>2000}", a, want);
+
+            let mut want = "0".repeat(2000 - 1026);
+            want.push_str("0x");
+            want.extend(core::iter::repeat("ab").take(512));
+            test_display_hex!("{:0>#2000}", a, want);
         }
 
         // Precision and padding act the same as for strings in the stdlib (because we use `Formatter::pad`).
@@ -734,59 +747,91 @@ mod tests {
             // Precision gets the most significant bytes.
             // Remember the integer is number of hex chars not number of bytes.
             define_dummy!(4);
+
             test_display_hex!("{0:.4}", [0x12, 0x34, 0x56, 0x78], "1234");
             test_display_hex!("{0:.5}", [0x12, 0x34, 0x56, 0x78], "12345");
+
+            test_display_hex!("{0:#.4}", [0x12, 0x34, 0x56, 0x78], "0x1234");
+            test_display_hex!("{0:#.5}", [0x12, 0x34, 0x56, 0x78], "0x12345");
         }
 
         #[test]
         fn precision_with_padding_truncates() {
             // Precision gets the most significant bytes.
             define_dummy!(4);
+
             test_display_hex!("{0:10.4}", [0x12, 0x34, 0x56, 0x78], "1234      ");
             test_display_hex!("{0:10.5}", [0x12, 0x34, 0x56, 0x78], "12345     ");
+
+            test_display_hex!("{0:#10.4}", [0x12, 0x34, 0x56, 0x78], "0x1234      ");
+            test_display_hex!("{0:#10.5}", [0x12, 0x34, 0x56, 0x78], "0x12345     ");
         }
 
         #[test]
         fn precision_with_padding_pads_right() {
             define_dummy!(4);
+
             test_display_hex!("{0:10.20}", [0x12, 0x34, 0x56, 0x78], "12345678  ");
             test_display_hex!("{0:10.14}", [0x12, 0x34, 0x56, 0x78], "12345678  ");
+
+            test_display_hex!("{0:#12.20}", [0x12, 0x34, 0x56, 0x78], "0x12345678  ");
+            test_display_hex!("{0:#12.14}", [0x12, 0x34, 0x56, 0x78], "0x12345678  ");
         }
 
         #[test]
         fn precision_with_padding_pads_left() {
             define_dummy!(4);
+
             test_display_hex!("{0:>10.20}", [0x12, 0x34, 0x56, 0x78], "  12345678");
+
+            test_display_hex!("{0:>#12.20}", [0x12, 0x34, 0x56, 0x78], "  0x12345678");
         }
 
         #[test]
         fn precision_with_padding_pads_center() {
             define_dummy!(4);
+
             test_display_hex!("{0:^10.20}", [0x12, 0x34, 0x56, 0x78], " 12345678 ");
+
+            test_display_hex!("{0:^#12.20}", [0x12, 0x34, 0x56, 0x78], " 0x12345678 ");
         }
 
         #[test]
         fn precision_with_padding_pads_center_odd() {
             define_dummy!(4);
+
             test_display_hex!("{0:^11.20}", [0x12, 0x34, 0x56, 0x78], " 12345678  ");
+
+            test_display_hex!("{0:^#13.20}", [0x12, 0x34, 0x56, 0x78], " 0x12345678  ");
         }
 
         #[test]
         fn precision_does_not_extend() {
             define_dummy!(4);
+
             test_display_hex!("{0:.16}", [0x12, 0x34, 0x56, 0x78], "12345678");
+
+            test_display_hex!("{0:#.16}", [0x12, 0x34, 0x56, 0x78], "0x12345678");
         }
 
         #[test]
         fn padding_extends() {
             define_dummy!(2);
+
             test_display_hex!("{:0>8}", [0xab; 2], "0000abab");
+
+            test_display_hex!("{:0>#8}", [0xab; 2], "000xabab");
         }
 
         #[test]
         fn padding_does_not_truncate() {
             define_dummy!(4);
+
             test_display_hex!("{:0>4}", [0x12, 0x34, 0x56, 0x78], "12345678");
+            test_display_hex!("{:0>4}", [0x12, 0x34, 0x56, 0x78], "12345678");
+
+            test_display_hex!("{:0>#4}", [0x12, 0x34, 0x56, 0x78], "0x12345678");
+            test_display_hex!("{:0>#4}", [0x12, 0x34, 0x56, 0x78], "0x12345678");
         }
 
         #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -137,18 +137,7 @@ fn internal_display(bytes: &[u8], f: &mut fmt::Formatter, case: Case) -> fmt::Re
         }
     }
 
-    // Avoid division by zero and optimize for common case.
-    if pad_right > 0 {
-        encoder.clear();
-        let c = f.fill();
-        let chunk_len = encoder.put_filler(c, pad_right);
-        let padding = encoder.as_str();
-        for _ in 0..(pad_right / chunk_len) {
-            f.write_str(padding)?;
-        }
-        f.write_str(&padding[..((pad_right % chunk_len) * c.len_utf8())])?;
-    }
-    Ok(())
+    write_pad_right(f, pad_right, &mut encoder)
 }
 
 fn write_pad_left(
@@ -187,6 +176,25 @@ fn write_pad_left(
         0
     };
     Ok(pad_right)
+}
+
+fn write_pad_right(
+    f: &mut fmt::Formatter,
+    pad_right: usize,
+    encoder: &mut BufEncoder<1024>,
+) -> fmt::Result {
+    // Avoid division by zero and optimize for common case.
+    if pad_right > 0 {
+        encoder.clear();
+        let c = f.fill();
+        let chunk_len = encoder.put_filler(c, pad_right);
+        let padding = encoder.as_str();
+        for _ in 0..(pad_right / chunk_len) {
+            f.write_str(padding)?;
+        }
+        f.write_str(&padding[..((pad_right % chunk_len) * c.len_utf8())])?;
+    }
+    Ok(())
 }
 
 mod sealed {

--- a/src/display.rs
+++ b/src/display.rs
@@ -118,6 +118,9 @@ fn internal_display(bytes: &[u8], f: &mut fmt::Formatter, case: Case) -> fmt::Re
     let mut encoder = BufEncoder::<1024>::new(case);
     let pad_right = write_pad_left(f, bytes.len(), &mut encoder)?;
 
+    if f.alternate() {
+        f.write_str("0x")?;
+    }
     match f.precision() {
         Some(max) if bytes.len() > max / 2 => {
             write!(f, "{}", bytes[..(max / 2)].as_hex())?;
@@ -146,9 +149,11 @@ fn write_pad_left(
     encoder: &mut BufEncoder<1024>,
 ) -> Result<usize, fmt::Error> {
     let pad_right = if let Some(width) = f.width() {
+        // Add space for 2 characters if the '#' flag is set
+        let full_string_len = if f.alternate() { bytes_len * 2 + 2 } else { bytes_len * 2 };
         let string_len = match f.precision() {
-            Some(max) => core::cmp::min(max, bytes_len * 2),
-            None => bytes_len * 2,
+            Some(max) => core::cmp::min(max, full_string_len),
+            None => full_string_len,
         };
 
         if string_len < width {


### PR DESCRIPTION
`fmt_hex_exact` accounts for precision.

`DisplayArray` and `DisplayByteSlice` add the "0x" prefix if the '#' (alternate) flag is set.

Close #83 