### PR TITLE
Update to latest run_task script

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -160,7 +160,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1


### PR DESCRIPTION
Update the commit hash of `rust-bitcoin-maintainer-tools` to get at the latest version of `run_task`.