### PR TITLE
Feature gate import

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -30,7 +30,9 @@ use alloc::string::String;
 use core::borrow::Borrow;
 use core::fmt;
 
-use super::{Case, Table};
+use super::Case;
+#[cfg(any(test, feature = "std"))]
+use super::Table;
 use crate::buf_encoder::BufEncoder;
 
 /// Extension trait for types that can be displayed as hex.


### PR DESCRIPTION
`Table` is only used if `test` or `std` - feature gate it.

Fix: #130