### PR TITLE
Derive `PartialOrd` and `Ord` for `Case`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub use self::{
 };
 
 /// Possible case of hex.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Case {
     /// Produce lower-case chars (`[0-9a-f]`).
     ///


### PR DESCRIPTION
Currently the `Case` enum does not implement `PartialOrd` and `Ord`. This is an unnecessary restriction.

Done as part of the Rust API guidelines checklist.

ref: https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits