### PR TITLE
Add missing error re-exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,10 @@ pub(crate) use table::Table;
 #[doc(inline)]
 pub use self::{
     display::DisplayHex,
-    error::{OddLengthStringError, HexToBytesError, HexToArrayError, InvalidCharError},
+    error::{
+        HexToArrayError, HexToBytesError, InvalidCharError, InvalidLengthError,
+        OddLengthStringError, ToArrayError, ToBytesError,
+    },
     iter::{BytesToHexIter, HexToBytesIter, HexSliceToBytesIter},
     parse::FromHex,
 };


### PR DESCRIPTION
We should be re-exporting all the errors in this crate so downsteam can use `hex::FooError` and not have to do `hex::error::FooError`.

Add the missing error re-exports, with this applied all the error types from `error` are re-exported at the crate root.