### PR TITLE
Verify the API

### DIFF
--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -19,6 +19,7 @@ use super::{Case, Table};
 /// This is an important building block for fast hex-encoding. Because string writing tools
 /// provided by `core::fmt` involve dynamic dispatch and don't allow reserving capacity in strings
 /// buffering the hex and then formatting it is significantly faster.
+#[derive(Debug)]
 pub struct BufEncoder<const CAP: usize> {
     buf: ArrayString<CAP>,
     table: &'static Table,

--- a/src/display.rs
+++ b/src/display.rs
@@ -572,6 +572,7 @@ where
 /// and writes the source bytes to its inner `T` as hex characters.
 #[cfg(any(test, feature = "std"))]
 #[cfg_attr(docsrs, doc(cfg(any(test, feature = "std"))))]
+#[derive(Debug)]
 pub struct HexWriter<T> {
     writer: T,
     table: &'static Table,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -18,6 +18,7 @@ use crate::{Case, Table};
 pub type HexSliceToBytesIter<'a> = HexToBytesIter<HexDigitsIter<'a>>;
 
 /// Iterator yielding bytes decoded from an iterator of pairs of hex digits.
+#[derive(Debug)]
 pub struct HexToBytesIter<T: Iterator<Item = [u8; 2]>> {
     iter: T,
     original_len: usize,
@@ -181,6 +182,7 @@ impl<T: Iterator<Item = [u8; 2]> + ExactSizeIterator + FusedIterator> io::Read
 /// Generally you shouldn't need to refer to this or bother with it and just use
 /// [`HexToBytesIter::new`] consuming the returned value and use `HexSliceToBytesIter` if you need
 /// to refer to the iterator in your types.
+#[derive(Debug)]
 pub struct HexDigitsIter<'a> {
     // Invariant: the length of the chunks is 2.
     // Technically, this is `iter::Map` but we can't use it because fn is anonymous.
@@ -238,6 +240,7 @@ fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, (u8, bool)> {
 }
 
 /// Iterator over bytes which encodes the bytes and yields hex characters.
+#[derive(Debug)]
 pub struct BytesToHexIter<I>
 where
     I: Iterator,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ mod table {
     /// Table of hex chars.
     //
     // Correctness invariant: each byte in the table must be ASCII.
+    #[derive(Debug)]
     pub(crate) struct Table([u8; 16]);
 
     impl Table {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -72,6 +72,7 @@ where
 }
 
 /// Byte slice wrapper to serialize as a hex string in lowercase characters.
+#[derive(Debug)]
 pub struct SerializeBytesAsHex<'a>(pub &'a [u8]);
 
 impl serde::Serialize for SerializeBytesAsHex<'_> {
@@ -84,6 +85,7 @@ impl serde::Serialize for SerializeBytesAsHex<'_> {
 }
 
 /// Byte slice wrapper to serialize as a hex string in lowercase characters.
+#[derive(Debug)]
 pub struct SerializeBytesAsHexLower<'a>(pub &'a [u8]);
 
 impl serde::Serialize for SerializeBytesAsHexLower<'_> {
@@ -96,6 +98,7 @@ impl serde::Serialize for SerializeBytesAsHexLower<'_> {
 }
 
 /// Byte slice wrapper to serialize as a hex string in uppercase characters.
+#[derive(Debug)]
 pub struct SerializeBytesAsHexUpper<'a>(pub &'a [u8]);
 
 impl serde::Serialize for SerializeBytesAsHexUpper<'_> {

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Test the API surface of `hex-conservative`.
+//!
+//! The point of these tests is to check the API surface as opposed to test the API functionality.
+//!
+//! ref: <https://rust-lang.github.io/api-guidelines/about.html>
+
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use core::borrow::Borrow;
+use core::marker::PhantomData;
+use core::{fmt, slice};
+
+#[cfg(feature = "serde")]
+use hex_conservative::serde;
+// These imports test "typical" usage by user code.
+use hex_conservative::{
+    buf_encoder, display, BytesToHexIter, Case, DisplayHex as _, HexToArrayError, HexToBytesError,
+    InvalidCharError, InvalidLengthError, OddLengthStringError, ToArrayError, ToBytesError,
+};
+
+/// A struct that includes all public non-error enums.
+// C-COMMON-TRAITS excluding `Display`.
+// All public types implement Debug (C-DEBUG).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+struct Enums {
+    a: Case,
+}
+
+impl Enums {
+    fn new() -> Self { Self { a: Case::Lower } }
+}
+
+// Some arbitrary data to use.
+const HEX: &str = "deadbeef";
+const BYTES: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+const CAP: usize = 16; // BYTES.len() * 2
+
+/// A struct that includes all public non-error structs.
+#[derive(Debug)] // All public types implement Debug (C-DEBUG).
+struct Structs<'a, I, T>
+where
+    I: Iterator,
+    I::Item: Borrow<u8>,
+{
+    a: BytesToHexIter<I>,
+    b: buf_encoder::BufEncoder<CAP>,
+    c: display::DisplayArray<'a, CAP>,
+    d: display::DisplayByteSlice<'a>,
+    #[cfg(feature = "std")]
+    e: display::HexWriter<T>,
+    #[cfg(feature = "serde")]
+    f: serde::SerializeBytesAsHex<'a>,
+    #[cfg(feature = "serde")]
+    g: serde::SerializeBytesAsHexLower<'a>,
+    #[cfg(feature = "serde")]
+    h: serde::SerializeBytesAsHexUpper<'a>,
+    _i: PhantomData<T>, // For when `std` is not enabled.
+}
+
+impl Structs<'_, slice::Iter<'_, u8>, String> {
+    /// Constructs an arbitrary instance.
+    fn new() -> Self {
+        let iter = BYTES.iter();
+        Self {
+            a: BytesToHexIter::new(iter, Case::Lower),
+            b: buf_encoder::BufEncoder::new(Case::Lower),
+            c: BYTES.as_hex(),
+            d: BYTES[..].as_hex(),
+            #[cfg(feature = "std")]
+            e: display::HexWriter::new(String::new(), Case::Lower),
+            #[cfg(feature = "serde")]
+            f: serde::SerializeBytesAsHex(&BYTES),
+            #[cfg(feature = "serde")]
+            g: serde::SerializeBytesAsHexLower(&BYTES),
+            #[cfg(feature = "serde")]
+            h: serde::SerializeBytesAsHexUpper(&BYTES),
+            _i: PhantomData,
+        }
+    }
+}
+
+/// A struct that includes all public error types.
+// These derives are the policy of `rust-bitcoin` not Rust API guidelines.
+#[derive(Debug, Clone, PartialEq, Eq)] // All public types implement Debug (C-DEBUG).
+struct Errors {
+    a: ToArrayError,
+    b: ToBytesError,
+    c: HexToArrayError,
+    d: HexToBytesError,
+    e: InvalidCharError,
+    f: InvalidLengthError,
+    g: OddLengthStringError,
+}
+
+// `Debug` representation is never empty (C-DEBUG-NONEMPTY).
+#[test]
+fn api_all_non_error_types_have_non_empty_debug() {
+    let debug = format!("{:?}", Case::Lower);
+    assert!(!debug.is_empty());
+
+    let t = Structs::new();
+
+    let debug = format!("{:?}", t.a);
+    assert!(!debug.is_empty());
+    let debug = format!("{:?}", t.b);
+    assert!(!debug.is_empty());
+    let debug = format!("{:?}", t.c);
+    assert!(!debug.is_empty());
+    let debug = format!("{:?}", t.d);
+    assert!(!debug.is_empty());
+    #[cfg(feature = "std")]
+    let debug = format!("{:?}", t.e);
+    assert!(!debug.is_empty());
+    #[cfg(feature = "serde")]
+    {
+        let debug = format!("{:?}", t.f);
+        assert!(!debug.is_empty());
+        let debug = format!("{:?}", t.g);
+        assert!(!debug.is_empty());
+        let debug = format!("{:?}", t.h);
+        assert!(!debug.is_empty());
+    }
+}
+
+#[test]
+fn all_types_implement_send_sync() {
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
+    //  Types are `Send` and `Sync` where possible (C-SEND-SYNC).
+    assert_send::<Enums>();
+    assert_sync::<Enums>();
+    assert_send::<Structs<'_, slice::Iter<'_, u8>, String>>();
+    assert_sync::<Structs<'_, slice::Iter<'_, u8>, String>>();
+
+    // Error types should implement the Send and Sync traits (C-GOOD-ERR).
+    assert_send::<Errors>();
+    assert_sync::<Errors>();
+}


### PR DESCRIPTION
Add an integration test module to prove the API surface of this crate. Done as part of #125.

- Patch 1: Derive `Debug`
- Patch 2: Add explicit trait bound to the `HexWriter`
- Patch 3: Add the test module

This was pulled out of #136