### PR TITLE
Add an functionally empty dyn compatibility test

### DIFF
--- a/tests/api.rs
+++ b/tests/api.rs
@@ -140,3 +140,11 @@ fn all_types_implement_send_sync() {
     assert_send::<Errors>();
     assert_sync::<Errors>();
 }
+
+#[test]
+fn dyn_compatible() {
+    // If this builds then traits are dyn compatible.
+    struct Traits {
+        // a: Box<dyn hex_conservative::FromHex>, // `from_hex()` returns `Self`.gs
+    }
+}


### PR DESCRIPTION
In order to complete the API guidelines checklist add a test that is functionally empty but exists as documentation about the single public trait in this crate.

At a bare minimum it saves one wondering why the test wasn't added and having to check the trait, then look up what make dyn compatibility not possible ...