### PR TITLE
Remove `FromHex` from `hexy` example

### DIFF
--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -46,7 +46,11 @@ impl fmt::Display for Hexy {
 impl FromStr for Hexy {
     type Err = HexToArrayError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> { Hexy::from_hex(s) }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Errors if the input is invalid
+        let a = <[u8; 32] as FromHex>::from_hex(s)?;
+        Ok(Hexy { data: a })
+    }
 }
 
 // Implement conversion to hex by first converting our type to a byte slice.
@@ -64,17 +68,5 @@ impl fmt::UpperHex for Hexy {
         // This is equivalent to but more performant than:
         // fmt::UpperHex::fmt(&self.as_bytes().as_hex(), f)
         fmt_hex_exact!(f, 32, self.as_bytes(), Case::Upper)
-    }
-}
-
-// And use a fixed size array to convert from hex.
-
-impl FromHex for Hexy {
-    type Error = HexToArrayError;
-
-    fn from_hex(s: &str) -> Result<Self, Self::Error> {
-        // Errors if the input is invalid
-        let a = <[u8; 32] as FromHex>::from_hex(s)?;
-        Ok(Hexy { data: a })
     }
 }


### PR DESCRIPTION
The `hexy` example is specifically supposed to showcase a type for which the natural representation is hexadecimal. It does not need to implement `FromHex`.

Remove the `FromHex` impl and inline the logic into `FromStr`.

Done as part of #139