### PR TITLE
Add a test that an odd capacity `BufEncoder` does not compile

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,3 +24,4 @@ Run from rust.yml unless stated otherwise. Unfortunately we are now exceeding th
 10. `Arch32bit`
 11. `Cross`
 12. `Format`
+13. `Compile tests`

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -218,3 +218,14 @@ jobs:
         run: rustup component add rustfmt
       - name: "Check formatting"
         run: cargo +nightly fmt --all -- --check
+
+  Compile:
+    name: Compile tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v4
+      - name: "Select toolchain"
+        uses: dtolnay/rust-toolchain@stable
+      - name: "Run compile tests"
+        run: ./contrib/compile-tests.sh

--- a/contrib/compile-tests.sh
+++ b/contrib/compile-tests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Checks intended compile failures.
+
+set -euo pipefail
+
+REPO_DIR=$(git rev-parse --show-toplevel)
+
+compile_check() {
+    local dir_path=$1
+    local expected_status=$2
+    local result=0
+    local output
+    # All crates in the specified subdirectory must compile or fail based on expected_status
+    for dir in "$dir_path"/*; do
+        if [ -d "$dir" ]; then
+            pushd "$dir" > /dev/null
+            echo "Compiling $dir"
+            output=$(cargo build 2>&1)
+            if [ "$?" -ne "$expected_status" ]; then
+                if [ "$expected_status" -eq 0 ]; then
+                    echo "$output"
+                    echo "error: compile-tests/$dir/ failed to compile"
+                else
+                    echo "error: compile-tests/$dir/ compiled when it should not have"
+                fi
+                result=1
+            fi
+            popd > /dev/null
+        fi
+    done
+    return "$result"
+}
+
+# Check that all files in compiletests pass or fail as expected
+cd "$REPO_DIR"/tests/compile-tests
+if compile_check "pass" 0 && compile_check "fail" 101; then
+    echo "Compile tests passed"
+    exit 0
+else
+    echo "Compile tests failed"
+    exit 1
+fi

--- a/tests/compile-tests/fail/odd-capacity/Cargo.toml
+++ b/tests/compile-tests/fail/odd-capacity/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "odd-capacity"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.63.0"
+
+[workspace]
+
+[dependencies]
+hex = { package = "hex-conservative", path = "../../../../" }

--- a/tests/compile-tests/fail/odd-capacity/src/main.rs
+++ b/tests/compile-tests/fail/odd-capacity/src/main.rs
@@ -1,0 +1,6 @@
+use hex::buf_encoder::BufEncoder;
+use hex::Case;
+
+// This should fail to compile because the capacity size is odd.
+// The only difference to `even-capacity` is the capacity size.
+fn main() { let _encoder = BufEncoder::<3>::new(Case::Lower); }

--- a/tests/compile-tests/pass/even-capacity/Cargo.toml
+++ b/tests/compile-tests/pass/even-capacity/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "even-capacity"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.63.0"
+
+[workspace]
+
+[dependencies]
+hex = { package = "hex-conservative", path = "../../../../" }

--- a/tests/compile-tests/pass/even-capacity/src/main.rs
+++ b/tests/compile-tests/pass/even-capacity/src/main.rs
@@ -1,0 +1,5 @@
+use hex::buf_encoder::BufEncoder;
+use hex::Case;
+
+// This should compile, ensuring that the compile error in odd-capacity is from the odd capacity.
+fn main() { let _encoder = BufEncoder::<4>::new(Case::Lower); }


### PR DESCRIPTION
An even capacity `BufEncoder` is now enforced and should be tested to make sure it does not compile if an odd capacity is used.

Adds a crate in tests that uses an odd capacity `BufEncoder`.

Adds a CI test that passes if the odd capacity crate fails to compile.

Close #155