### PR TITLE
Add tests to kill all mutants in `hex-conservative`

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,12 @@
+additional_cargo_args = ["--all-features"]
+examine_globs = ["src/**/*.rs"]
+exclude_globs = [
+]
+exclude_re = [
+    "serde", # Skip serde mutation tests
+    "Iterator", # Mutating operations in an iterator can result in an infinite loop
+    "write_pad_left", # Timeout
+    "write_pad_right", # Mutant changes `* 1` to `/ 1` which has no effect
+    "hex_reserve_suggestion", # Mutant changes the suggested number bytes to reserve when creating a `String` to 0 or 1. This has a possible performance impact but is not a correctness issue.
+    "fmt_hex_exact_fn", # Mutant changes a `/ 2` to `* 2` in the number of elements in the iterator. Only the required number of elements are returned so the mutant has no functional change to test.
+]

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 Cargo.lock
 target
+
+# Test artifacts
+mutants.out*

--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -252,6 +252,19 @@ mod tests {
     }
 
     #[test]
+    fn put_filler() {
+        let mut encoder = BufEncoder::<8>::new(Case::Lower);
+        assert_eq!(encoder.put_filler(' ', 0), 0);
+        assert_eq!(encoder.as_str(), "");
+        assert_eq!(encoder.put_filler('a', 1), 1);
+        assert_eq!(encoder.as_str(), "a");
+        assert_eq!(encoder.put_filler('é', 2), 2); // Test 2 byte UTF-8
+        assert_eq!(encoder.as_str(), "aéé");
+        assert_eq!(encoder.put_filler('é', 4), 1); // Try to fill more than fits
+        assert_eq!(encoder.as_str(), "aééé");
+    }
+
+    #[test]
     fn same_as_fmt() {
         use core::fmt::{self, Write};
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -969,6 +969,15 @@ mod tests {
             let got = format!("{}", tc);
             assert_eq!(got, want);
         }
+
+        #[test]
+        fn hex_display_case() {
+            let bytes = [0xaa, 0xbb, 0xcc, 0xdd];
+            let upper = "AABBCCDD";
+            let lower = "aabbccdd";
+            assert_eq!(bytes.to_upper_hex_string(), upper);
+            assert_eq!(bytes.to_lower_hex_string(), lower);
+        }
     }
 
     #[cfg(feature = "std")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -260,7 +260,7 @@ impl fmt::Display for InvalidLengthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "invilad hex string length {} (expected {})",
+            "invalid hex string length {} (expected {})",
             self.invalid_length(),
             self.expected_length()
         )

--- a/src/error.rs
+++ b/src/error.rs
@@ -269,3 +269,70 @@ impl fmt::Display for InvalidLengthError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidLengthError {}
+
+#[cfg(test)]
+#[cfg(feature = "std")]
+mod tests {
+    use super::*;
+    use crate::FromHex;
+
+    fn check_source<T: std::error::Error>(error: &T) {
+        assert!(error.source().is_some());
+    }
+
+    #[test]
+    fn invalid_char_error() {
+        let result = <Vec<u8> as FromHex>::from_hex("12G4");
+        let error = result.unwrap_err();
+        if let HexToBytesError(ToBytesError::InvalidChar(e)) = error {
+            assert!(!format!("{}", e).is_empty());
+            assert_eq!(e.invalid_char(), b'G');
+            assert_eq!(e.pos(), 2);
+        } else {
+            panic!("Expected InvalidCharError");
+        }
+    }
+
+    #[test]
+    fn odd_length_string_error() {
+        let result = <Vec<u8> as FromHex>::from_hex("123");
+        let error = result.unwrap_err();
+        assert!(!format!("{}", error).is_empty());
+        check_source(&error);
+        if let HexToBytesError(ToBytesError::OddLengthString(e)) = error {
+            assert!(!format!("{}", e).is_empty());
+            assert_eq!(e.length(), 3);
+        } else {
+            panic!("Expected OddLengthStringError");
+        }
+    }
+
+    #[test]
+    fn invalid_length_error() {
+        let result = <[u8; 4] as FromHex>::from_hex("123");
+        let error = result.unwrap_err();
+        assert!(!format!("{}", error).is_empty());
+        check_source(&error);
+        if let HexToArrayError(ToArrayError::InvalidLength(e)) = error {
+            assert!(!format!("{}", e).is_empty());
+            assert_eq!(e.expected_length(), 8);
+            assert_eq!(e.invalid_length(), 3);
+        } else {
+            panic!("Expected InvalidLengthError");
+        }
+    }
+
+    #[test]
+    fn to_bytes_error() {
+        let error = ToBytesError::OddLengthString(OddLengthStringError { len: 7 });
+        assert!(!format!("{}", error).is_empty());
+        check_source(&error);
+    }
+
+    #[test]
+    fn to_array_error() {
+        let error = ToArrayError::InvalidLength(InvalidLengthError { expected: 8, invalid: 7 });
+        assert!(!format!("{}", error).is_empty());
+        check_source(&error);
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -589,4 +589,31 @@ mod tests {
             BytesToHexIter::new(upper_bytes_iter, Case::Upper).rev().collect::<String>();
         assert_eq!(upper_got, upper_want);
     }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn hex_to_bytes_iter_read() {
+        use std::io::Read;
+
+        let hex = "deadbeef";
+        let mut iter = HexToBytesIter::new(hex).unwrap();
+        let mut buf = [0u8; 4];
+        let bytes_read = iter.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 4);
+        assert_eq!(buf, [0xde, 0xad, 0xbe, 0xef]);
+
+        let hex = "deadbeef";
+        let mut iter = HexToBytesIter::new(hex).unwrap();
+        let mut buf = [0u8; 2];
+        let bytes_read = iter.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 2);
+        assert_eq!(buf, [0xde, 0xad]);
+
+        let hex = "deadbeef";
+        let mut iter = HexToBytesIter::new(hex).unwrap();
+        let mut buf = [0u8; 6];
+        let bytes_read = iter.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 4);
+        assert_eq!(buf[..4], [0xde, 0xad, 0xbe, 0xef]);
+    }
 }


### PR DESCRIPTION
All the mutants found by `cargo mutants` have been killed by adding tests or when needed adding an exception to `mutants.toml`