### PR TITLE
Inline small functions

### DIFF
--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -145,6 +145,7 @@ impl<const CAP: usize> BufEncoder<CAP> {
 }
 
 impl<const CAP: usize> Default for BufEncoder<CAP> {
+    #[inline]
     fn default() -> Self { Self::new(Case::Lower) }
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -58,6 +58,7 @@ pub trait DisplayHex: Copy + sealed::IsRef + sealed::Sealed {
     ///
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
+    #[inline]
     fn to_lower_hex_string(self) -> String { self.to_hex_string(Case::Lower) }
 
     /// Create an upper-hex-encoded string.
@@ -66,6 +67,7 @@ pub trait DisplayHex: Copy + sealed::IsRef + sealed::Sealed {
     ///
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
+    #[inline]
     fn to_upper_hex_string(self) -> String { self.to_hex_string(Case::Upper) }
 
     /// Create a hex-encoded string.
@@ -272,24 +274,29 @@ pub struct DisplayByteSlice<'a> {
 }
 
 impl DisplayByteSlice<'_> {
+    #[inline]
     fn display(&self, f: &mut fmt::Formatter, case: Case) -> fmt::Result {
         internal_display(self.bytes, f, case)
     }
 }
 
 impl fmt::Display for DisplayByteSlice<'_> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
 }
 
 impl fmt::Debug for DisplayByteSlice<'_> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
 }
 
 impl fmt::LowerHex for DisplayByteSlice<'_> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Lower) }
 }
 
 impl fmt::UpperHex for DisplayByteSlice<'_> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Upper) }
 }
 
@@ -312,24 +319,29 @@ impl<'a, const CAP: usize> DisplayArray<'a, CAP> {
         DisplayArray { array }
     }
 
+    #[inline]
     fn display(&self, f: &mut fmt::Formatter, case: Case) -> fmt::Result {
         internal_display(self.array, f, case)
     }
 }
 
 impl<const LEN: usize> fmt::Display for DisplayArray<'_, LEN> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
 }
 
 impl<const LEN: usize> fmt::Debug for DisplayArray<'_, LEN> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
 }
 
 impl<const LEN: usize> fmt::LowerHex for DisplayArray<'_, LEN> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Lower) }
 }
 
 impl<const LEN: usize> fmt::UpperHex for DisplayArray<'_, LEN> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Upper) }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,21 +31,25 @@ macro_rules! write_err {
 pub struct HexToBytesError(pub(crate) ToBytesError);
 
 impl From<Infallible> for HexToBytesError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl HexToBytesError {
     /// Returns a [`ToBytesError`] from this [`HexToBytesError`].
     // Use clone instead of reference to give use maximum forward flexibility.
+    #[inline]
     pub fn parse_error(&self) -> ToBytesError { self.0.clone() }
 }
 
 impl fmt::Display for HexToBytesError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
 #[cfg(feature = "std")]
 impl std::error::Error for HexToBytesError {
+    #[inline]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
@@ -69,6 +73,7 @@ pub enum ToBytesError {
 }
 
 impl From<Infallible> for ToBytesError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -114,17 +119,21 @@ pub struct InvalidCharError {
 }
 
 impl From<Infallible> for InvalidCharError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl InvalidCharError {
     /// Returns the invalid character byte.
+    #[inline]
     pub fn invalid_char(&self) -> u8 { self.invalid }
     /// Returns the position of the invalid character byte.
+    #[inline]
     pub fn pos(&self) -> usize { self.pos }
 }
 
 impl fmt::Display for InvalidCharError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "invalid hex char {} at pos {}", self.invalid_char(), self.pos())
     }
@@ -140,15 +149,18 @@ pub struct OddLengthStringError {
 }
 
 impl From<Infallible> for OddLengthStringError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl OddLengthStringError {
     /// Returns the odd length of the input string.
+    #[inline]
     pub fn length(&self) -> usize { self.len }
 }
 
 impl fmt::Display for OddLengthStringError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "odd hex string length {}", self.length())
     }
@@ -162,21 +174,25 @@ impl std::error::Error for OddLengthStringError {}
 pub struct HexToArrayError(pub(crate) ToArrayError);
 
 impl From<Infallible> for HexToArrayError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl HexToArrayError {
     /// Returns a [`ToArrayError`] from this [`HexToArrayError`].
     // Use clone instead of reference to give use maximum forward flexibility.
+    #[inline]
     pub fn parse_error(&self) -> ToArrayError { self.0.clone() }
 }
 
 impl fmt::Display for HexToArrayError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
 #[cfg(feature = "std")]
 impl std::error::Error for HexToArrayError {
+    #[inline]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
@@ -200,6 +216,7 @@ pub enum ToArrayError {
 }
 
 impl From<Infallible> for ToArrayError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -246,13 +263,16 @@ pub struct InvalidLengthError {
 }
 
 impl From<Infallible> for InvalidLengthError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl InvalidLengthError {
     /// Returns the expected length.
+    #[inline]
     pub fn expected_length(&self) -> usize { self.expected }
     /// Returns the position of the invalid character byte.
+    #[inline]
     pub fn invalid_length(&self) -> usize { self.invalid }
 }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -42,6 +42,7 @@ impl<'a> HexToBytesIter<HexDigitsIter<'a>> {
         }
     }
 
+    #[inline]
     pub(crate) fn new_unchecked(s: &'a str) -> Self {
         Self::from_pairs(HexDigitsIter::new_unchecked(s.as_bytes()))
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,6 +25,7 @@ pub trait FromHex: Sized + sealed::Sealed {
 impl FromHex for Vec<u8> {
     type Error = HexToBytesError;
 
+    #[inline]
     fn from_hex(s: &str) -> Result<Self, Self::Error> {
         Ok(HexToBytesIter::new(s)?.drain_to_vec()?)
     }


### PR DESCRIPTION
Functions that just delegate or do trivial operations should be inline.

Add `#[inline]` to all functions that fit the criteria.