### PR TITLE
Bump GitHub Actions Artifacts to v4

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -39,7 +39,7 @@ encode,
       - name: fuzz
         run: cd fuzz && ./fuzz.sh "${{ matrix.fuzz_target }}"
       - run: echo "${{ matrix.fuzz_target }}" >executed_${{ matrix.fuzz_target }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: executed_${{ matrix.fuzz_target }}
           path: executed_${{ matrix.fuzz_target }}
@@ -50,7 +50,7 @@ encode,
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - name: Display structure of downloaded files
         run: ls -R
       - run: find executed_* -type f -exec cat {} + | sort > executed

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -83,7 +83,7 @@ $(for name in $(listTargetNames); do echo "$name,"; done)
       - name: fuzz
         run: cd fuzz && ./fuzz.sh "\${{ matrix.fuzz_target }}"
       - run: echo "\${{ matrix.fuzz_target }}" >executed_\${{ matrix.fuzz_target }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: executed_\${{ matrix.fuzz_target }}
           path: executed_\${{ matrix.fuzz_target }}
@@ -94,7 +94,7 @@ $(for name in $(listTargetNames); do echo "$name,"; done)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - name: Display structure of downloaded files
         run: ls -R
       - run: find executed_* -type f -exec cat {} + | sort > executed


### PR DESCRIPTION
v3 is deprecated and causes an automatic fail of fuzz workflow.

Bump the version of `actions/upload-artifact` and `actions/download-artifact` to v4.