### PR TITLE
Release tracking PR: `v0.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.4.0 - 2025-03-17
+
+- Introduce crate level decoding functions [#166](https://github.com/rust-bitcoin/hex-conservative/pull/166)
+- Remove default impl of `hex_reserve_suggestion` [#158](https://github.com/rust-bitcoin/hex-conservative/pull/158)
+- Enforce `BufEncoder` capacity check for evenness [#155](https://github.com/rust-bitcoin/hex-conservative/pull/155)
+- Seal all public traits [#152](https://github.com/rust-bitcoin/hex-conservative/pull/152)
+- Implement `From<Infallible>` for all error types [#149](https://github.com/rust-bitcoin/hex-conservative/pull/149)
+- Make `HexToBytes` trait bounds consistent [#148](https://github.com/rust-bitcoin/hex-conservative/pull/148)
+- Make `write_err` macro private [#134](https://github.com/rust-bitcoin/hex-conservative/pull/134)
+- Hide error internals [#129](https://github.com/rust-bitcoin/hex-conservative/pull/129)
+
 # 0.3.0 - 2024-09-18
 
 - Re-implement `HexWriter` [#113](https://github.com/rust-bitcoin/hex-conservative/pull/113)

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -16,7 +16,7 @@ checksum = "5edd69c67b2f8e0911629b7e6b8a34cb3956613cd7c6e6414966dee349c2db4f"
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -10,7 +10,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"


### PR DESCRIPTION
Draft so that #169 can go in.

In preparation for release add a changelog entry, bump the version, and update the lock files.

This release is to release what is on master because the upcoming alpha release (#162) has code from master. 

