### PR TITLE
rename error types of new decoding functions

### DIFF
--- a/examples/hexy.rs
+++ b/examples/hexy.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use hex_conservative::{
-    fmt_hex_exact, Case, DecodeFixedSizedBytesError, DisplayHex as _, FromHex as _,
+    fmt_hex_exact, Case, DecodeFixedLengthBytesError, DisplayHex as _, FromHex as _,
 };
 
 fn main() {
@@ -48,7 +48,7 @@ impl fmt::Display for Hexy {
 }
 
 impl FromStr for Hexy {
-    type Err = DecodeFixedSizedBytesError;
+    type Err = DecodeFixedLengthBytesError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Errors if the input is invalid

--- a/examples/wrap_array.rs
+++ b/examples/wrap_array.rs
@@ -7,7 +7,7 @@
 use core::fmt;
 use core::str::FromStr;
 
-use hex_conservative::{DecodeFixedSizedBytesError, DisplayHex as _, FromHex as _};
+use hex_conservative::{DecodeFixedLengthBytesError, DisplayHex as _, FromHex as _};
 
 fn main() {
     let hex = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeefcafebabe";
@@ -72,6 +72,6 @@ impl fmt::UpperHex for Wrap {
 }
 
 impl FromStr for Wrap {
-    type Err = DecodeFixedSizedBytesError;
+    type Err = DecodeFixedLengthBytesError;
     fn from_str(s: &str) -> Result<Self, Self::Err> { Ok(Self(<[u8; 32]>::from_hex(s)?)) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub(crate) use table::Table;
 pub use self::{
     display::DisplayHex,
     error::{
-        DecodeFixedSizedBytesError, DecodeDynSizedBytesError, InvalidCharError, InvalidLengthError,
+        DecodeFixedLengthBytesError, DecodeDynSizedBytesError, InvalidCharError, InvalidLengthError,
         OddLengthStringError,
     },
     iter::{BytesToHexIter, HexToBytesIter, HexSliceToBytesIter},
@@ -143,7 +143,7 @@ pub fn decode_to_vec(hex: &str) -> Result<Vec<u8>, DecodeDynSizedBytesError> {
 ///
 /// Returns an error if `hex` contains invalid characters or has incorrect length. (Should be
 /// `N * 2`.)
-pub fn decode_to_array<const N: usize>(hex: &str) -> Result<[u8; N], DecodeFixedSizedBytesError> {
+pub fn decode_to_array<const N: usize>(hex: &str) -> Result<[u8; N], DecodeFixedLengthBytesError> {
     if hex.len() == N * 2 {
         let mut ret = [0u8; N];
         // checked above

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub(crate) use table::Table;
 pub use self::{
     display::DisplayHex,
     error::{
-        DecodeFixedLengthBytesError, DecodeDynSizedBytesError, InvalidCharError, InvalidLengthError,
+        DecodeFixedLengthBytesError, DecodeVariableLengthBytesError, InvalidCharError, InvalidLengthError,
         OddLengthStringError,
     },
     iter::{BytesToHexIter, HexToBytesIter, HexSliceToBytesIter},
@@ -130,7 +130,7 @@ pub use self::{
 ///
 /// Returns an error if `hex` contains invalid characters or doesn't have even length.
 #[cfg(feature = "alloc")]
-pub fn decode_to_vec(hex: &str) -> Result<Vec<u8>, DecodeDynSizedBytesError> {
+pub fn decode_to_vec(hex: &str) -> Result<Vec<u8>, DecodeVariableLengthBytesError> {
     Ok(HexToBytesIter::new(hex)?.drain_to_vec()?)
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -8,7 +8,7 @@ use core::{fmt, str};
 use crate::alloc::vec::Vec;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::{DecodeDynSizedBytesError, DecodeFixedSizedBytesError};
+pub use crate::error::{DecodeDynSizedBytesError, DecodeFixedLengthBytesError};
 
 /// Trait for objects that can be deserialized from hex strings.
 pub trait FromHex: Sized + sealed::Sealed {
@@ -32,7 +32,7 @@ impl FromHex for Vec<u8> {
 }
 
 impl<const LEN: usize> FromHex for [u8; LEN] {
-    type Error = DecodeFixedSizedBytesError;
+    type Error = DecodeFixedLengthBytesError;
 
     fn from_hex(s: &str) -> Result<Self, Self::Error> { crate::decode_to_array(s) }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -8,7 +8,7 @@ use core::{fmt, str};
 use crate::alloc::vec::Vec;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::error::{DecodeDynSizedBytesError, DecodeFixedLengthBytesError};
+pub use crate::error::{DecodeVariableLengthBytesError, DecodeFixedLengthBytesError};
 
 /// Trait for objects that can be deserialized from hex strings.
 pub trait FromHex: Sized + sealed::Sealed {
@@ -25,7 +25,7 @@ pub trait FromHex: Sized + sealed::Sealed {
 
 #[cfg(feature = "alloc")]
 impl FromHex for Vec<u8> {
-    type Error = DecodeDynSizedBytesError;
+    type Error = DecodeVariableLengthBytesError;
 
     #[inline]
     fn from_hex(s: &str) -> Result<Self, Self::Error> { crate::decode_to_vec(s) }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -17,8 +17,8 @@ use core::{fmt, slice};
 use hex_conservative::serde;
 // These imports test "typical" usage by user code.
 use hex_conservative::{
-    buf_encoder, display, BytesToHexIter, Case, DecodeDynSizedBytesError,
-    DecodeFixedLengthBytesError, DisplayHex as _, InvalidCharError, InvalidLengthError,
+    buf_encoder, display, BytesToHexIter, Case, DecodeFixedLengthBytesError,
+    DecodeVariableLengthBytesError, DisplayHex as _, InvalidCharError, InvalidLengthError,
     OddLengthStringError,
 };
 
@@ -88,7 +88,7 @@ impl Structs<'_, slice::Iter<'_, u8>, String> {
 #[derive(Debug, Clone, PartialEq, Eq)] // All public types implement Debug (C-DEBUG).
 struct Errors {
     c: DecodeFixedLengthBytesError,
-    d: DecodeDynSizedBytesError,
+    d: DecodeVariableLengthBytesError,
     e: InvalidCharError,
     f: InvalidLengthError,
     g: OddLengthStringError,

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -18,7 +18,7 @@ use hex_conservative::serde;
 // These imports test "typical" usage by user code.
 use hex_conservative::{
     buf_encoder, display, BytesToHexIter, Case, DecodeDynSizedBytesError,
-    DecodeFixedSizedBytesError, DisplayHex as _, InvalidCharError, InvalidLengthError,
+    DecodeFixedLengthBytesError, DisplayHex as _, InvalidCharError, InvalidLengthError,
     OddLengthStringError,
 };
 
@@ -87,7 +87,7 @@ impl Structs<'_, slice::Iter<'_, u8>, String> {
 // These derives are the policy of `rust-bitcoin` not Rust API guidelines.
 #[derive(Debug, Clone, PartialEq, Eq)] // All public types implement Debug (C-DEBUG).
 struct Errors {
-    c: DecodeFixedSizedBytesError,
+    c: DecodeFixedLengthBytesError,
     d: DecodeDynSizedBytesError,
     e: InvalidCharError,
     f: InvalidLengthError,


### PR DESCRIPTION
The old names were incoherent at best.