### PR TITLE
Bump version to 1.0 - BOOM!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0 - 2025-06-12
+
+No changes from rc-1.
+
 # 1.0.0 release candidate 1 -- 2025-05-16
 
 - Exports `decode_to_array`, `decode_to_vec`, and all error types.

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "hex-conservative"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 dependencies = [
  "if_rust_version",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "hex-conservative"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 dependencies = [
  "if_rust_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"


### PR DESCRIPTION
The latest release candidate has been downstream tested enough to give us confidence that this release is ready - lets go!

In preparation for release add a changelog entry, bump the version number, and update the lock files.