### PR TITLE
Remove the `HexToBytesIter` from the public API

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -29,7 +29,8 @@ impl<'a> HexToBytesIter<HexDigitsIter<'a>> {
     ///
     /// If the input string is of odd length.
     #[inline]
-    pub fn new(s: &'a str) -> Result<Self, OddLengthStringError> {
+    #[allow(dead_code)] // Remove this when making HexToBytesIter public.
+    pub(crate) fn new(s: &'a str) -> Result<Self, OddLengthStringError> {
         if s.len() % 2 != 0 {
             Err(OddLengthStringError { len: s.len() })
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ mod iter;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use crate::iter::HexToBytesIter;
+
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
@@ -72,7 +74,6 @@ pub use self::{
         DecodeFixedLengthBytesError, DecodeVariableLengthBytesError, InvalidCharError, InvalidLengthError,
         OddLengthStringError,
     },
-    iter::HexToBytesIter,
 };
 
 /// Decodes a hex string with variable length.


### PR DESCRIPTION
Face palm! - Thanks goodness for the RC cycle. No clue how this slipped by us.