### PR TITLE
Release tracking PR: `v1.0.0-rc.2`.

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "hex-conservative"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "if_rust_version",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "hex-conservative"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "if_rust_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"


### PR DESCRIPTION
We just removed the `HexToBytesIter` from the public API. Cut another RC candidate.
    
No need for a changelog. Bump the version and update the lock files.
