### PR TITLE
backport: Return error on invalid hex for io::Read on HexToBytesIter

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -178,7 +178,8 @@ where
                     *dst = src;
                     bytes_read += 1;
                 }
-                _ => break,
+                Some(Err(e)) => return Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+                None => break,
             }
         }
         Ok(bytes_read)
@@ -445,5 +446,11 @@ mod tests {
         let bytes_read = iter.read(&mut buf).unwrap();
         assert_eq!(bytes_read, 4);
         assert_eq!(buf[..4], [0xde, 0xad, 0xbe, 0xef]);
+
+        let hex = "deadbeefXX";
+        let mut iter = HexToBytesIter::new(hex).unwrap();
+        let mut buf = [0u8; 6];
+        let err = iter.read(&mut buf).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 }


### PR DESCRIPTION
Backport the bugfix in #178 

Currently this test passes, and it should not.

```rust
fn main() {
	let good_hex = "deadbeef00deadbeef";
	let bad_hex = "deadbeefXX00XXdeadbeef";

	let mut buf = vec![];
	let mut iter = HexToBytesIter::new(good_hex).unwrap();
	iter.read_to_end(&mut buf).unwrap();
	assert_eq!(buf.as_hex().to_string(), good_hex);

	let mut buf = vec![];
	let mut iter = HexToBytesIter::new(bad_hex).unwrap();
	iter.read_to_end(&mut buf).unwrap();
	assert_eq!(buf.as_hex().to_string(), good_hex);
}
```

Created using: git cherry-pick b67244c 