### PR TITLE
Remove reexports of low-level error types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to hex-conservative
+
+Thanks for the interest in contributing!
+Before you do anything, please familiarize yourself with the stabilization strategy as described in the README, since it places some restrictions on how the code is developed.
+
+## Contributing to the stable crate
+
+Generally, you should try to make your contributions against the `master` branch which contains unstable code and thus it's much more forgiving when it comes to adding any new features.
+However it may be sometimes impossible, in which case please follow these rules:
+
+1. Breaking any API of the 1.0 crate is unacceptable unless it can be done with semver trick (e.g. feature modifictaions). Please do not even attempt to do this.
+2. For new APIs, please gate all of them behing `#[cfg(hex-conservative-unstable)]` to ensure they won't get used by accident. The stabilization procedure is similar to that of Rust itself.
+3. Once a new unstable API is released, try using it in a real project. (Ideally multiple different projects.)
+4. If you want to get an unstable feature stabilized, write a stabilization report that contains at least one Open Source project that uses it and a summary of how well the feature works in practice.
+5. Any new feature should be out for at least 6 months before stabilization to give projects enough chance to test it out. We may make exceptions for particularly simple and desirable features.
+
+## General rules
+
+First and formost, all code has to produce correct results and have API that models a domain accurately and makes it hard to do wrong things.
+If any other rule is in conflict with the first rule, the first rule takes precedence.
+Both encoding and decoding should be reasonably fast. Please avoid unneeded allocations or other kinds of code that cause slowness.
+All code should be idiomatic, reasonably consistent and maintainable. This includes high importance of "single source of truth" because violating it is extremely prone to causing bugs.
+
+## Githooks
+
+To assist devs in catching errors _before_ running CI we provide some githooks. If you do not
+already have locally configured githooks you can use the ones in this repository by running, in the
+root directory of the repository:
+```
+git config --local core.hooksPath githooks/
+```
+
+Alternatively add symlinks in your `.git/hooks` directory to any of the githooks we provide.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ explicit_into_iter_loop = "warn"
 explicit_iter_loop = "warn"
 filter_map_next = "warn"
 flat_map_option = "warn"
-float_cmp = "allow" # Bitcoin floats are typically limited to 8 decimal places and we want them exact.
 fn_params_excessive_bools = "warn"
 from_iter_instead_of_collect = "warn"
 if_not_else = "warn"

--- a/README.md
+++ b/README.md
@@ -44,15 +44,3 @@ included in Debian stable (1.63 is in Debian 12 at the moment).
 
 Note though that the dependencies may have looser policy. This is not considered
 breaking/wrong - you would just need to pin them in `Cargo.lock` (not `.toml`).
-
-
-## Githooks
-
-To assist devs in catching errors _before_ running CI we provide some githooks. If you do not
-already have locally configured githooks you can use the ones in this repository by running, in the
-root directory of the repository:
-```
-git config --local core.hooksPath githooks/
-```
-
-Alternatively add symlinks in your `.git/hooks` directory to any of the githooks we provide.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 General purpose hex encoding/decoding library with a conservative MSRV and dependency policy.
 
+**You're currently looking at the stable crate which has advanced features removed** to make
+stabilization quicker and thus allowing downstream crates to stabilize quicker too. To get the
+full feature set check the lower (0.x.y) versions. Read Stabilization strategy section for more
+information.
+
 ## Stabilization strategy
 
 Because downstream crates may need to return hex errors in their APIs and they need to be

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Error code for the `hex-conservative` crate.
+//! The error types.
+//!
+//! These types are returned when hex decoding fails. The high-level ones are
+//! [`DecodeFixedLengthBytesError`] and [`DecodeVariableLengthBytesError`] which represent all
+//! possible ways in which hex decoding may fail in the two most common decoding scenarios.
 
 use core::convert::Infallible;
 use core::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,7 @@ use crate::iter::HexToBytesIter;
 #[doc(inline)]
 pub use self::{
     error::{
-        DecodeFixedLengthBytesError, DecodeVariableLengthBytesError, InvalidCharError, InvalidLengthError,
-        OddLengthStringError,
+        DecodeFixedLengthBytesError, DecodeVariableLengthBytesError,
     },
 };
 
@@ -106,7 +105,7 @@ pub fn decode_to_array<const N: usize>(hex: &str) -> Result<[u8; N], DecodeFixed
         HexToBytesIter::new_unchecked(hex).drain_to_slice(&mut ret)?;
         Ok(ret)
     } else {
-        Err(InvalidLengthError { invalid: hex.len(), expected: 2 * N }.into())
+        Err(error::InvalidLengthError { invalid: hex.len(), expected: 2 * N }.into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@
 //! version is at least two years old and also included in Debian stable (1.63 is in Debian 12 at
 //! the moment).
 //!
-//! Note though that the dependencies may have looser policy. This is not considered breaking/wrong
-//! - you would just need to pin them in `Cargo.lock` (not `.toml`).
+//! Note though that the dependencies may have looser policy. This is not considered
+//! breaking/wrong - you would just need to pin them in `Cargo.lock` (not `.toml`).
 
 #![no_std]
 // Experimental features we need.

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -9,10 +9,8 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
-use hex_conservative::{
-    DecodeFixedLengthBytesError, DecodeVariableLengthBytesError, InvalidCharError,
-    InvalidLengthError, OddLengthStringError,
-};
+use hex_conservative::error::{InvalidCharError, InvalidLengthError, OddLengthStringError};
+use hex_conservative::{DecodeFixedLengthBytesError, DecodeVariableLengthBytesError};
 
 /// A struct that includes all public error types.
 // These derives are the policy of `hex-conservative` not Rust API guidelines.

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -20,7 +20,7 @@ const BYTES: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
 const CAP: usize = 16; // BYTES.len() * 2
 
 /// A struct that includes all public error types.
-// These derives are the policy of `rust-bitcoin` not Rust API guidelines.
+// These derives are the policy of `hex-conservative` not Rust API guidelines.
 #[derive(Debug, Clone, PartialEq, Eq)] // All public types implement Debug (C-DEBUG).
 struct Errors {
     c: DecodeFixedLengthBytesError,

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -14,11 +14,6 @@ use hex_conservative::{
     InvalidLengthError, OddLengthStringError,
 };
 
-// Some arbitrary data to use.
-const HEX: &str = "deadbeef";
-const BYTES: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-const CAP: usize = 16; // BYTES.len() * 2
-
 /// A struct that includes all public error types.
 // These derives are the policy of `hex-conservative` not Rust API guidelines.
 #[derive(Debug, Clone, PartialEq, Eq)] // All public types implement Debug (C-DEBUG).
@@ -39,4 +34,51 @@ fn all_types_implement_send_sync() {
     // Error types should implement the Send and Sync traits (C-GOOD-ERR).
     assert_send::<Errors>();
     assert_sync::<Errors>();
+}
+
+const VALID: &str = "deadbeef";
+const VALID_UPPER: &str = "DEADBEEF";
+const VALID_MIXED: &str = "dEaDBeEf";
+const TOO_SHORT: &str = "deadbee";
+const TOO_LONG: &str = "deadcaffe";
+const INVALID_CHAR: &str = "deadreef";
+const EXPECTED: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+
+#[test]
+fn decode_to_array() {
+    assert_eq!(hex_conservative::decode_to_array::<4>(VALID).unwrap(), EXPECTED);
+    assert_eq!(hex_conservative::decode_to_array::<4>(VALID_UPPER).unwrap(), EXPECTED);
+    assert_eq!(hex_conservative::decode_to_array::<4>(VALID_MIXED).unwrap(), EXPECTED);
+    match hex_conservative::decode_to_array::<4>(TOO_SHORT).unwrap_err() {
+        DecodeFixedLengthBytesError::InvalidLength(error) => assert_eq!(error.invalid_length(), 7),
+        DecodeFixedLengthBytesError::InvalidChar(_) => panic!("unexpected error"),
+    }
+    match hex_conservative::decode_to_array::<4>(TOO_LONG).unwrap_err() {
+        DecodeFixedLengthBytesError::InvalidLength(error) => assert_eq!(error.invalid_length(), 9),
+        DecodeFixedLengthBytesError::InvalidChar(_) => panic!("unexpected error"),
+    }
+    match hex_conservative::decode_to_array::<4>(INVALID_CHAR).unwrap_err() {
+        DecodeFixedLengthBytesError::InvalidLength(_) => panic!("unexpected error"),
+        DecodeFixedLengthBytesError::InvalidChar(error) => assert_eq!(error.pos(), 4),
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn decode_to_vec() {
+    assert_eq!(hex_conservative::decode_to_vec(VALID).unwrap(), EXPECTED);
+    assert_eq!(hex_conservative::decode_to_vec(VALID_UPPER).unwrap(), EXPECTED);
+    assert_eq!(hex_conservative::decode_to_vec(VALID_MIXED).unwrap(), EXPECTED);
+    match hex_conservative::decode_to_vec(TOO_SHORT).unwrap_err() {
+        DecodeVariableLengthBytesError::OddLengthString(error) => assert_eq!(error.length(), 7),
+        DecodeVariableLengthBytesError::InvalidChar(_) => panic!("unexpected error"),
+    }
+    match hex_conservative::decode_to_vec(TOO_LONG).unwrap_err() {
+        DecodeVariableLengthBytesError::OddLengthString(error) => assert_eq!(error.length(), 9),
+        DecodeVariableLengthBytesError::InvalidChar(_) => panic!("unexpected error"),
+    }
+    match hex_conservative::decode_to_vec(INVALID_CHAR).unwrap_err() {
+        DecodeVariableLengthBytesError::OddLengthString(_) => panic!("unexpected error"),
+        DecodeVariableLengthBytesError::InvalidChar(error) => assert_eq!(error.pos(), 4),
+    }
 }


### PR DESCRIPTION
This is done on top of #183 because it might be controversial, so only the last commit is relevant (though we could just merge this one). If this is merged I deem the crate ready for stabilization. However if this approach is rejected I still want to do something about the API duplication before 1.0.

The crate contains a public `error` module but also reexports all of its
content which just makes the API redundant. There were three possible
solutions:

* unpublish the `error` module
* remove all reexports
* remove only some reexports

This commit choses to remove low-level reexports because while it's
plausible that the downstream crates will want to use the high-level
ones in their API, mentioning the low-level ones should be rare.