### PR TITLE
Implement top level encode API

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -3,9 +3,25 @@
 version = 3
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex-conservative"
 version = "1.0.0"
 dependencies = [
+ "hex-conservative 0.3.0",
  "if_rust_version",
 ]
 

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -3,9 +3,25 @@
 version = 3
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex-conservative"
 version = "1.0.0"
 dependencies = [
+ "hex-conservative 0.3.0",
  "if_rust_version",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["std"]
 std = ["alloc"]
-alloc = []
+alloc = ["hex-unstable/alloc"]
 # Enables detection of newer rust versions to provide additional features
 # Turning it on may pull in dependencies that run build scripts and prolong compile time.
 # This feature will do nothing once our MSRV supports version detection natively and will
@@ -27,6 +27,7 @@ alloc = []
 newer-rust-version = ["dep:if_rust_version"]
 
 [dependencies]
+hex-unstable = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 if_rust_version = { version = "1.0.0", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ pub mod error;
 mod iter;
 
 #[cfg(feature = "alloc")]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 use crate::iter::HexToBytesIter;
@@ -107,6 +109,44 @@ pub fn decode_to_array<const N: usize>(hex: &str) -> Result<[u8; N], DecodeFixed
     } else {
         Err(error::InvalidLengthError { invalid: hex.len(), expected: 2 * N }.into())
     }
+}
+
+/// Encodes `data` as hex string using lowercase characters.
+///
+/// Lowercase characters are used (e.g. `f9b4ca`). The resulting string's length is always even,
+/// each byte in `data` is always encoded using two hex digits. Thus, the resulting string contains
+/// exactly twice as many bytes as the input data.
+///
+/// # Example
+///
+/// ```
+/// use hex_conservative as hex;
+/// assert_eq!(hex::encode_lower("Hello world!"), "48656c6c6f20776f726c6421");
+/// assert_eq!(hex::encode_lower(vec![1, 2, 3, 15, 16]), "0102030f10");
+/// ```
+#[must_use]
+#[cfg(feature = "alloc")]
+pub fn encode_lower<T: AsRef<[u8]>>(data: T) -> String {
+    use hex_unstable::prelude::DisplayHex as _;
+    data.as_ref().to_lower_hex_string()
+}
+
+/// Encodes `data` as hex string using uppercase characters.
+///
+/// Apart from the characters' casing, this works exactly like `encode_lower()`.
+///
+/// # Example
+///
+/// ```
+/// use hex_conservative as hex;
+/// assert_eq!(hex::encode_upper("Hello world!"), "48656C6C6F20776F726C6421");
+/// assert_eq!(hex::encode_upper(vec![1, 2, 3, 15, 16]), "0102030F10");
+/// ```
+#[must_use]
+#[cfg(feature = "alloc")]
+pub fn encode_upper<T: AsRef<[u8]>>(data: T) -> String {
+    use hex_unstable::prelude::DisplayHex as _;
+    data.as_ref().to_upper_hex_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add two functions that do as the name suggests, returning `String`:

- `encode_lower`
- `encode_upper`

Feature gate both on `alloc`.

Implement both by adding a dependency on the pre-1.0 version of `hex-conservative`.