### PR TITLE
Fix deserialization

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "dtoa"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edd69c67b2f8e0911629b7e6b8a34cb3956613cd7c6e6414966dee349c2db4f"
-
-[[package]]
 name = "hex-conservative"
 version = "0.3.0"
 dependencies = [
@@ -51,9 +45,9 @@ checksum = "46dbcb333e86939721589d25a3557e180b52778cb33c7fdfe9e0158ff790d5ec"
 
 [[package]]
 name = "itoa"
-version = "0.3.0"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd9dc2c587067de817fec4ad355e3818c3d893a78cab32a0a474c7a15bb8d5"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -75,12 +69,6 @@ checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "num-traits"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51eab148f171aefad295f8cece636fc488b9b392ef544da31ea4b8ef6b9e9c39"
 
 [[package]]
 name = "proc-macro2"
@@ -110,6 +98,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "semver"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,13 +131,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.0"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b1ec939469a124b27e208106550c38358ed4334d2b1b5b3825bc1ee37d946a"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
- "dtoa",
  "itoa",
- "num-traits",
+ "ryu",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.156", features = ["derive"] }
-serde_json = "1.0"
+serde_json = "1.0.48"
 
 [[example]]
 name = "hexy"

--- a/src/display.rs
+++ b/src/display.rs
@@ -1028,8 +1028,20 @@ mod tests {
             }
 
             test_hex_writer!(0, Lower, &[], Result::Ok(0), "");
-            test_hex_writer!(0, Lower, &[0xab, 0xcd], Result::Err(ErrorKind::Other.into()), "");
-            test_hex_writer!(1, Lower, &[0xab, 0xcd], Result::Err(ErrorKind::Other.into()), "");
+            test_hex_writer!(
+                0,
+                Lower,
+                &[0xab, 0xcd],
+                Result::<usize>::Err(ErrorKind::Other.into()),
+                ""
+            );
+            test_hex_writer!(
+                1,
+                Lower,
+                &[0xab, 0xcd],
+                Result::<usize>::Err(ErrorKind::Other.into()),
+                ""
+            );
             test_hex_writer!(2, Lower, &[0xab, 0xcd], Result::Ok(1), "ab");
             test_hex_writer!(3, Lower, &[0xab, 0xcd], Result::Ok(1), "ab");
             test_hex_writer!(4, Lower, &[0xab, 0xcd], Result::Ok(2), "abcd");

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -437,7 +437,7 @@ mod tests {
         assert_eq!(got, want);
 
         let hex = "";
-        let want = [];
+        let want: [u8; 0] = [];
         let iter = HexToBytesIter::new_unchecked(hex);
         let mut got = [];
         iter.drain_to_slice(&mut got).unwrap();

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -156,8 +156,31 @@ where
 
     // Don't do anything special when not human readable.
     if d.is_human_readable() {
-        d.deserialize_map(HexVisitor(PhantomData))
+        d.deserialize_str(HexVisitor(PhantomData))
     } else {
         serde::Deserialize::deserialize(d)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn serialize_lower_roundtrip() -> Result<(), serde_json::Error> {
+        let bytes: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+        let serialized: serde_json::Value =
+            super::serialize_lower(&bytes, serde_json::value::Serializer)?;
+        let deserialized: [u8; 4] = super::deserialize(serialized)?;
+        assert_eq!(bytes, deserialized);
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_upper_roundtrip() -> Result<(), serde_json::Error> {
+        let bytes: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+        let serialized: serde_json::Value =
+            super::serialize_upper(&bytes, serde_json::value::Serializer)?;
+        let deserialized: [u8; 4] = super::deserialize(serialized)?;
+        assert_eq!(bytes, deserialized);
+        Ok(())
     }
 }


### PR DESCRIPTION
Fixes #189.

The changes in [src/display.rs](https://github.com/rust-bitcoin/hex-conservative/pull/188/files#diff-aab9bd06633e7680dd7ac54f81eb5007b79dde5dbbde9e0613e040edd766e89a) and [src/iter.rs](https://github.com/rust-bitcoin/hex-conservative/pull/188/files#diff-4bc73dd48e6ccc80311431323609ad12765c3635b53eebe2deaa4be10ecd9be6) were necessary, since using `serde_json` in tests brings an `impl PartialEq<serde_json::Value> for usize` into context, which makes some code in the aforementioned tests ambiguous without explicitly specifying types
