### PR TITLE
Add const hex macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add `hex!` macro for const hex literal parsing.
+
 # 0.3.0 - 2024-09-18
 
 - Re-implement `HexWriter` [#113](https://github.com/rust-bitcoin/hex-conservative/pull/113)


### PR DESCRIPTION
Adds a `hex!` macro for parsing hex strings in const contexts, based on [hex_lit](https://github.com/Kixunil/hex_lit).

Closes #193