### PR TITLE
Backport 188 serde deserialization bug

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "dtoa"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edd69c67b2f8e0911629b7e6b8a34cb3956613cd7c6e6414966dee349c2db4f"
-
-[[package]]
 name = "hex-conservative"
 version = "0.3.1"
 dependencies = [
@@ -44,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd9dc2c587067de817fec4ad355e3818c3d893a78cab32a0a474c7a15bb8d5"
+checksum = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 
 [[package]]
 name = "lazy_static"
@@ -68,12 +62,6 @@ checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "num-traits"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51eab148f171aefad295f8cece636fc488b9b392ef544da31ea4b8ef6b9e9c39"
 
 [[package]]
 name = "proc-macro2"
@@ -103,6 +91,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+
+[[package]]
 name = "semver"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,13 +124,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.0"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b1ec939469a124b27e208106550c38358ed4334d2b1b5b3825bc1ee37d946a"
+checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 dependencies = [
- "dtoa",
  "itoa",
- "num-traits",
+ "ryu",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.156", features = ["derive"] }
-serde_json = "1.0"
+serde_json = "1.0.48"
 
 [[example]]
 name = "hexy"

--- a/src/display.rs
+++ b/src/display.rs
@@ -839,8 +839,20 @@ mod tests {
             }
 
             test_hex_writer!(0, Lower, &[], Result::Ok(0), "");
-            test_hex_writer!(0, Lower, &[0xab, 0xcd], Result::Err(ErrorKind::Other.into()), "");
-            test_hex_writer!(1, Lower, &[0xab, 0xcd], Result::Err(ErrorKind::Other.into()), "");
+            test_hex_writer!(
+                0,
+                Lower,
+                &[0xab, 0xcd],
+                Result::<usize>::Err(ErrorKind::Other.into()),
+                ""
+            );
+            test_hex_writer!(
+                1,
+                Lower,
+                &[0xab, 0xcd],
+                Result::<usize>::Err(ErrorKind::Other.into()),
+                ""
+            );
             test_hex_writer!(2, Lower, &[0xab, 0xcd], Result::Ok(1), "ab");
             test_hex_writer!(3, Lower, &[0xab, 0xcd], Result::Ok(1), "ab");
             test_hex_writer!(4, Lower, &[0xab, 0xcd], Result::Ok(2), "abcd");

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -417,7 +417,7 @@ mod tests {
         assert_eq!(got, want);
 
         let hex = "";
-        let want = [];
+        let want: [u8; 0] = [];
         let iter = HexToBytesIter::new_unchecked(hex);
         let mut got = [];
         iter.drain_to_slice(&mut got).unwrap();

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -139,6 +139,29 @@ where
     if !d.is_human_readable() {
         serde::Deserialize::deserialize(d)
     } else {
-        d.deserialize_map(HexVisitor(PhantomData))
+        d.deserialize_str(HexVisitor(PhantomData))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn serialize_lower_roundtrip() -> Result<(), serde_json::Error> {
+        let bytes: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+        let serialized: serde_json::Value =
+            super::serialize_lower(&bytes, serde_json::value::Serializer)?;
+        let deserialized: [u8; 4] = super::deserialize(serialized)?;
+        assert_eq!(bytes, deserialized);
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_upper_roundtrip() -> Result<(), serde_json::Error> {
+        let bytes: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+        let serialized: serde_json::Value =
+            super::serialize_upper(&bytes, serde_json::value::Serializer)?;
+        let deserialized: [u8; 4] = super::deserialize(serialized)?;
+        assert_eq!(bytes, deserialized);
+        Ok(())
     }
 }


### PR DESCRIPTION
PR #188 fixes issue #189, a bug in serde deserialization.

Manual backport of e1fa1d8f80779d2ee9d5ba2e70dbcfe914a41db0 because it did not cherry-pick cleanly.

Patch adds a dev dependency that causes the MSRV build to choke. Update the `Cargo-minimal.lock` by using `-Z minimal-versions`.
    
And then pin `proc-macro2` back to what it was with:  `cargo update -p proc-macro2 --precise  1.0.63`
