### PR TITLE
Make `iter` module public

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -29,8 +29,7 @@ impl<'a> HexToBytesIter<HexDigitsIter<'a>> {
     ///
     /// If the input string is of odd length.
     #[inline]
-    #[allow(dead_code)] // Remove this when making HexToBytesIter public.
-    pub(crate) fn new(s: &'a str) -> Result<Self, OddLengthStringError> {
+    pub fn new(s: &'a str) -> Result<Self, OddLengthStringError> {
         if s.len() % 2 != 0 {
             Err(OddLengthStringError { len: s.len() })
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod _export {
 }
 
 pub mod error;
-mod iter;
+pub mod iter;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;


### PR DESCRIPTION
Do a couple of preparatory patches then make the module pubic as well as the `HexToBytesIter::new` constructor. With this applied exactly two types will be added to the public API: `HexToBytesIter` and the helper `HexDigitsIter`. The former can only be constructed using `new` and the latter does not provide a constructor. It is meant for usage only if one needs to refer to the iter type explicitly as `HexToBytesIter<HexDigitsIter>`.

Note we do not add the `HexSliceToBytesIter` alias from master. If required that can be done as a follow up because as is this PR only touches code on the 1.x branch already.