### PR TITLE
Release tracking PR: `hex v1.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
-# Unreleased
+# 1.1.0 - 2026-05-04
+
+`v1.0` of this crate only has the decoding side (and the decoding iterator is private).
+
+This next release introduces the encoding side of the library and also makes the
+iterator types public - enjoy. 
+
+- Prepare master to be `v1.1` [#206](https://github.com/rust-bitcoin/hex-conservative/pull/206)
+  - Delete `serde` module
+  - Delete `FromHex` trait
+- Convert `DisplayHex` to use GAT [#215](https://github.com/rust-bitcoin/hex-conservative/pull/215https://github.com/rust-bitcoin/hex-conservative/pull/215)
+- Bump MSRV to Rust `v1.74.0`
+  - [#216](https://github.com/rust-bitcoin/hex-conservative/pull/216)
+  - [#228](https://github.com/rust-bitcoin/hex-conservative/pull/228)
+- Derive standard traits on all types [#221](https://github.com/rust-bitcoin/hex-conservative/pull/221)
+- Add `FromIterator` and `Extend` to `BufEncoder` [#223](https://github.com/rust-bitcoin/hex-conservative/pull/223)
+- Remove `serde` dependencies [#224](https://github.com/rust-bitcoin/hex-conservative/pull/224)
+- Convert `HexSliceToBytesIter` to a newtype instead of an alias [#227](https://github.com/rust-bitcoin/hex-conservative/pull/227)
+- Implement `nth` and `nth_back` [#232](https://github.com/rust-bitcoin/hex-conservative/pull/232)
+- Fix `InvalidCharError` position with mixed reading on `HexToBytesIter` [#235](https://github.com/rust-bitcoin/hex-conservative/pull/235)
+- Introduce `Char` enum and rewrite `BytesToHexIter` to return it [#236](https://github.com/rust-bitcoin/hex-conservative/pull/236)
+- Use `Char` table lookup to improve decode performance [#243](https://github.com/rust-bitcoin/hex-conservative/pull/243)
+- `Char` improvements [#242](https://github.com/rust-bitcoin/hex-conservative/pull/242)
+- Align `fmt_hex_exact` and `Display` impls [#127](https://github.com/rust-bitcoin/hex-conservative/pull/127)
+
+# 0.3.2 - 2026-01-28
 
 - Add `hex!` macro for const hex literal parsing.
 - Bump the MSRV

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -10,7 +10,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.0"
+version = "1.1.0"
 dependencies = [
  "arrayvec",
  "if_rust_version",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -10,7 +10,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.0"
+version = "1.1.0"
 dependencies = [
  "arrayvec",
  "if_rust_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "0.3.0"
+version = "1.1.0"
 authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"


### PR DESCRIPTION
`v1.0` of this crate only has the decoding side (and the decoding iterator is private).

This next release introduces the encoding side of the library and also makes the iterator types public - enjoy. 
