### PR TITLE
docs: Cleanup and remove stabalization strategy section

### DIFF
--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -2,7 +2,7 @@
 
 //! Implements a buffered encoder.
 //!
-//! This is a low-level module, most uses should be satisfied by the `display` module instead.
+//! This is a low-level module, most users should be satisfied by the `display` module instead.
 //!
 //! The main type in this module is [`BufEncoder`] which provides buffered hex encoding.
 //! `BufEncoder` is faster than the usual `write!(f, "{02x}", b)?` in a for loop because it reduces

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,19 +43,6 @@
 //! # }
 //! ```
 //!
-//! ## Stabilization strategy
-//!
-//! Because downstream crates may need to return hex errors in their APIs and they need to be
-//! stabilized soon, this crate only exposes the errors and two basic decoding functions. This
-//! should already help with the vast majority of the cases and we're sufficiently confident that
-//! these errors won't have a breaking change any time soon (possibly never).
-//!
-//! If you're writing a binary you don't need to worry about any of this and just use the unstable
-//! version for now. If you're writing a library you should use these stable errors in the API but
-//! you may internally depend on the unstable crate version to get the advanced features that won't
-//! affect your API. This way your API can stabilize before all features in this crate are fully
-//! stable and you still can use all of them.
-//!
 //! ## Crate feature flags
 //!
 //! * `std` - enables the standard library, on by default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Hex encoding and decoding.
+//! # Hex encoding and decoding
 //!
 //! General purpose hex encoding/decoding library with a conservative MSRV and dependency policy.
 //!


### PR DESCRIPTION
As part of the push to stabalize the whole crate remove the 'stabalization strategy' section from the crate docs. And o a couple of trivial docs fixes. 