### PR TITLE
Convert DisplayHex to use GAT

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -44,40 +44,6 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::from(t: T) -> T
 pub mod hex_conservative::display
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::display::impl_fmt_traits!
-pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
-impl<const LEN: usize> core::fmt::Debug for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<const LEN: usize> core::fmt::Display for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<const LEN: usize> core::fmt::LowerHex for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<const LEN: usize> core::fmt::UpperHex for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<'a, const CAP: usize> core::marker::Freeze for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::UnsafeUnpin for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::panic::unwind_safe::UnwindSafe for hex_conservative::display::DisplayArray<'a, CAP>
-impl<T, U> core::convert::Into<U> for hex_conservative::display::DisplayArray<'a, CAP> where U: core::convert::From<T>
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for hex_conservative::display::DisplayArray<'a, CAP> where U: core::convert::Into<T>
-pub type hex_conservative::display::DisplayArray<'a, CAP>::Error = core::convert::Infallible
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for hex_conservative::display::DisplayArray<'a, CAP> where U: core::convert::TryFrom<T>
-pub type hex_conservative::display::DisplayArray<'a, CAP>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for hex_conservative::display::DisplayArray<'a, CAP> where T: core::fmt::Display + ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for hex_conservative::display::DisplayArray<'a, CAP> where T: 'static + ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for hex_conservative::display::DisplayArray<'a, CAP> where T: ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for hex_conservative::display::DisplayArray<'a, CAP> where T: ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for hex_conservative::display::DisplayArray<'a, CAP>
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::from(t: T) -> T
 pub struct hex_conservative::display::DisplayByteSlice<'a>
 impl core::fmt::Debug for hex_conservative::display::DisplayByteSlice<'_>
 pub fn hex_conservative::display::DisplayByteSlice<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -144,130 +110,18 @@ impl<T> core::borrow::BorrowMut<T> for hex_conservative::display::HexWriter<T> w
 pub fn hex_conservative::display::HexWriter<T>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for hex_conservative::display::HexWriter<T>
 pub fn hex_conservative::display::HexWriter<T>::from(t: T) -> T
-pub trait hex_conservative::display::DisplayHex: core::marker::Copy + hex_conservative::display::sealed::IsRef + hex_conservative::display::sealed::Sealed
-pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub fn hex_conservative::display::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
-pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
-pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
-pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1024]
-pub type &'a [u8; 1024]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1024]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 10]
-pub type &'a [u8; 10]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 10]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 11]
-pub type &'a [u8; 11]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 11]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 128]
-pub type &'a [u8; 128]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 128]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 12]
-pub type &'a [u8; 12]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 12]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 13]
-pub type &'a [u8; 13]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 13]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 14]
-pub type &'a [u8; 14]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 14]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 15]
-pub type &'a [u8; 15]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 15]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 16]
-pub type &'a [u8; 16]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 16]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1]
-pub type &'a [u8; 1]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2048]
-pub type &'a [u8; 2048]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2048]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 20]
-pub type &'a [u8; 20]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 20]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 256]
-pub type &'a [u8; 256]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 256]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2]
-pub type &'a [u8; 2]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 32]
-pub type &'a [u8; 32]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 32]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 33]
-pub type &'a [u8; 33]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 33]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 3]
-pub type &'a [u8; 3]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 3]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4096]
-pub type &'a [u8; 4096]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4096]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4]
-pub type &'a [u8; 4]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 512]
-pub type &'a [u8; 512]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 512]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 5]
-pub type &'a [u8; 5]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 5]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 64]
-pub type &'a [u8; 64]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 64]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 65]
-pub type &'a [u8; 65]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 65]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 6]
-pub type &'a [u8; 6]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 6]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
-pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 7]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
-pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
-pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 9]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
-pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a [u8]::as_hex(self) -> Self::Display
-pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
-pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
-pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
+pub trait hex_conservative::display::DisplayHex
+pub type hex_conservative::display::DisplayHex::Display<'a> where Self: 'a: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn hex_conservative::display::DisplayHex::append_hex_to_string<'a>(&'a self, case: hex_conservative::Case, string: &mut alloc::string::String)
+pub fn hex_conservative::display::DisplayHex::as_hex<'a>(&'a self) -> Self::Display
+pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(&self) -> usize
+pub fn hex_conservative::display::DisplayHex::to_hex_string(&self, case: hex_conservative::Case) -> alloc::string::String
+pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(&self) -> alloc::string::String
+pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(&self) -> alloc::string::String
+impl hex_conservative::display::DisplayHex for [u8]
+pub type [u8]::Display<'a> = hex_conservative::display::DisplayByteSlice<'a>
+pub fn [u8]::as_hex<'a>(&'a self) -> Self::Display
+pub fn [u8]::hex_reserve_suggestion(&self) -> usize
 pub mod hex_conservative::error
 pub enum hex_conservative::error::DecodeFixedLengthBytesError
 pub hex_conservative::error::DecodeFixedLengthBytesError::InvalidChar(hex_conservative::error::InvalidCharError)
@@ -532,130 +386,18 @@ pub unsafe fn hex_conservative::error::OddLengthStringError::clone_to_uninit(&se
 impl<T> core::convert::From<T> for hex_conservative::error::OddLengthStringError
 pub fn hex_conservative::error::OddLengthStringError::from(t: T) -> T
 pub mod hex_conservative::prelude
-pub trait hex_conservative::prelude::DisplayHex: core::marker::Copy + hex_conservative::display::sealed::IsRef + hex_conservative::display::sealed::Sealed
-pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
-pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
-pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
-pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1024]
-pub type &'a [u8; 1024]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1024]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 10]
-pub type &'a [u8; 10]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 10]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 11]
-pub type &'a [u8; 11]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 11]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 128]
-pub type &'a [u8; 128]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 128]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 12]
-pub type &'a [u8; 12]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 12]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 13]
-pub type &'a [u8; 13]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 13]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 14]
-pub type &'a [u8; 14]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 14]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 15]
-pub type &'a [u8; 15]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 15]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 16]
-pub type &'a [u8; 16]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 16]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1]
-pub type &'a [u8; 1]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2048]
-pub type &'a [u8; 2048]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2048]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 20]
-pub type &'a [u8; 20]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 20]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 256]
-pub type &'a [u8; 256]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 256]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2]
-pub type &'a [u8; 2]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 32]
-pub type &'a [u8; 32]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 32]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 33]
-pub type &'a [u8; 33]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 33]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 3]
-pub type &'a [u8; 3]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 3]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4096]
-pub type &'a [u8; 4096]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4096]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4]
-pub type &'a [u8; 4]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 512]
-pub type &'a [u8; 512]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 512]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 5]
-pub type &'a [u8; 5]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 5]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 64]
-pub type &'a [u8; 64]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 64]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 65]
-pub type &'a [u8; 65]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 65]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 6]
-pub type &'a [u8; 6]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 6]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
-pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 7]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
-pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
-pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 9]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
-pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a [u8]::as_hex(self) -> Self::Display
-pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
-pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
-pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
+pub trait hex_conservative::prelude::DisplayHex
+pub type hex_conservative::prelude::DisplayHex::Display<'a> where Self: 'a: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string<'a>(&'a self, case: hex_conservative::Case, string: &mut alloc::string::String)
+pub fn hex_conservative::prelude::DisplayHex::as_hex<'a>(&'a self) -> Self::Display
+pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(&self) -> usize
+pub fn hex_conservative::prelude::DisplayHex::to_hex_string(&self, case: hex_conservative::Case) -> alloc::string::String
+pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(&self) -> alloc::string::String
+pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(&self) -> alloc::string::String
+impl hex_conservative::display::DisplayHex for [u8]
+pub type [u8]::Display<'a> = hex_conservative::display::DisplayByteSlice<'a>
+pub fn [u8]::as_hex<'a>(&'a self) -> Self::Display
+pub fn [u8]::hex_reserve_suggestion(&self) -> usize
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::hex!
 pub macro hex_conservative::impl_fmt_traits!
@@ -1097,129 +839,17 @@ impl<T> core::clone::CloneToUninit for hex_conservative::error::OddLengthStringE
 pub unsafe fn hex_conservative::error::OddLengthStringError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::error::OddLengthStringError
 pub fn hex_conservative::error::OddLengthStringError::from(t: T) -> T
-pub trait hex_conservative::DisplayHex: core::marker::Copy + hex_conservative::display::sealed::IsRef + hex_conservative::display::sealed::Sealed
-pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub fn hex_conservative::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
-pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
-pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
-pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1024]
-pub type &'a [u8; 1024]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1024]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 10]
-pub type &'a [u8; 10]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 10]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 11]
-pub type &'a [u8; 11]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 11]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 128]
-pub type &'a [u8; 128]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 128]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 12]
-pub type &'a [u8; 12]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 12]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 13]
-pub type &'a [u8; 13]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 13]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 14]
-pub type &'a [u8; 14]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 14]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 15]
-pub type &'a [u8; 15]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 15]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 16]
-pub type &'a [u8; 16]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 16]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1]
-pub type &'a [u8; 1]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2048]
-pub type &'a [u8; 2048]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2048]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 20]
-pub type &'a [u8; 20]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 20]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 256]
-pub type &'a [u8; 256]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 256]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2]
-pub type &'a [u8; 2]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 32]
-pub type &'a [u8; 32]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 32]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 33]
-pub type &'a [u8; 33]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 33]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 3]
-pub type &'a [u8; 3]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 3]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4096]
-pub type &'a [u8; 4096]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4096]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4]
-pub type &'a [u8; 4]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 512]
-pub type &'a [u8; 512]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 512]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 5]
-pub type &'a [u8; 5]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 5]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 64]
-pub type &'a [u8; 64]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 64]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 65]
-pub type &'a [u8; 65]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 65]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 6]
-pub type &'a [u8; 6]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 6]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
-pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 7]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
-pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
-pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 9]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
-pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a [u8]::as_hex(self) -> Self::Display
-pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
-pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
-pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
+pub trait hex_conservative::DisplayHex
+pub type hex_conservative::DisplayHex::Display<'a> where Self: 'a: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn hex_conservative::DisplayHex::append_hex_to_string<'a>(&'a self, case: hex_conservative::Case, string: &mut alloc::string::String)
+pub fn hex_conservative::DisplayHex::as_hex<'a>(&'a self) -> Self::Display
+pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(&self) -> usize
+pub fn hex_conservative::DisplayHex::to_hex_string(&self, case: hex_conservative::Case) -> alloc::string::String
+pub fn hex_conservative::DisplayHex::to_lower_hex_string(&self) -> alloc::string::String
+pub fn hex_conservative::DisplayHex::to_upper_hex_string(&self) -> alloc::string::String
+impl hex_conservative::display::DisplayHex for [u8]
+pub type [u8]::Display<'a> = hex_conservative::display::DisplayByteSlice<'a>
+pub fn [u8]::as_hex<'a>(&'a self) -> Self::Display
+pub fn [u8]::hex_reserve_suggestion(&self) -> usize
 pub fn hex_conservative::decode_to_array<const N: usize>(hex: &str) -> core::result::Result<[u8; N], hex_conservative::error::DecodeFixedLengthBytesError>
 pub fn hex_conservative::decode_to_vec(hex: &str) -> core::result::Result<alloc::vec::Vec<u8>, hex_conservative::error::DecodeVariableLengthBytesError>

--- a/api/alloc-only.txt
+++ b/api/alloc-only.txt
@@ -44,40 +44,6 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::from(t: T) -> T
 pub mod hex_conservative::display
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::display::impl_fmt_traits!
-pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
-impl<const LEN: usize> core::fmt::Debug for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<const LEN: usize> core::fmt::Display for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<const LEN: usize> core::fmt::LowerHex for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<const LEN: usize> core::fmt::UpperHex for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<'a, const CAP: usize> core::marker::Freeze for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::UnsafeUnpin for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::panic::unwind_safe::UnwindSafe for hex_conservative::display::DisplayArray<'a, CAP>
-impl<T, U> core::convert::Into<U> for hex_conservative::display::DisplayArray<'a, CAP> where U: core::convert::From<T>
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for hex_conservative::display::DisplayArray<'a, CAP> where U: core::convert::Into<T>
-pub type hex_conservative::display::DisplayArray<'a, CAP>::Error = core::convert::Infallible
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for hex_conservative::display::DisplayArray<'a, CAP> where U: core::convert::TryFrom<T>
-pub type hex_conservative::display::DisplayArray<'a, CAP>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::string::ToString for hex_conservative::display::DisplayArray<'a, CAP> where T: core::fmt::Display + ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for hex_conservative::display::DisplayArray<'a, CAP> where T: 'static + ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for hex_conservative::display::DisplayArray<'a, CAP> where T: ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for hex_conservative::display::DisplayArray<'a, CAP> where T: ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for hex_conservative::display::DisplayArray<'a, CAP>
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::from(t: T) -> T
 pub struct hex_conservative::display::DisplayByteSlice<'a>
 impl core::fmt::Debug for hex_conservative::display::DisplayByteSlice<'_>
 pub fn hex_conservative::display::DisplayByteSlice<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -112,130 +78,18 @@ impl<T> core::borrow::BorrowMut<T> for hex_conservative::display::DisplayByteSli
 pub fn hex_conservative::display::DisplayByteSlice<'a>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for hex_conservative::display::DisplayByteSlice<'a>
 pub fn hex_conservative::display::DisplayByteSlice<'a>::from(t: T) -> T
-pub trait hex_conservative::display::DisplayHex: core::marker::Copy + hex_conservative::display::sealed::IsRef + hex_conservative::display::sealed::Sealed
-pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub fn hex_conservative::display::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
-pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
-pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::display::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
-pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1024]
-pub type &'a [u8; 1024]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1024]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 10]
-pub type &'a [u8; 10]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 10]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 11]
-pub type &'a [u8; 11]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 11]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 128]
-pub type &'a [u8; 128]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 128]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 12]
-pub type &'a [u8; 12]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 12]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 13]
-pub type &'a [u8; 13]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 13]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 14]
-pub type &'a [u8; 14]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 14]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 15]
-pub type &'a [u8; 15]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 15]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 16]
-pub type &'a [u8; 16]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 16]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1]
-pub type &'a [u8; 1]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2048]
-pub type &'a [u8; 2048]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2048]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 20]
-pub type &'a [u8; 20]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 20]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 256]
-pub type &'a [u8; 256]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 256]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2]
-pub type &'a [u8; 2]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 32]
-pub type &'a [u8; 32]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 32]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 33]
-pub type &'a [u8; 33]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 33]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 3]
-pub type &'a [u8; 3]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 3]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4096]
-pub type &'a [u8; 4096]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4096]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4]
-pub type &'a [u8; 4]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 512]
-pub type &'a [u8; 512]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 512]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 5]
-pub type &'a [u8; 5]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 5]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 64]
-pub type &'a [u8; 64]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 64]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 65]
-pub type &'a [u8; 65]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 65]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 6]
-pub type &'a [u8; 6]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 6]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
-pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 7]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
-pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
-pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 9]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
-pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a [u8]::as_hex(self) -> Self::Display
-pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
-pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
-pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
+pub trait hex_conservative::display::DisplayHex
+pub type hex_conservative::display::DisplayHex::Display<'a> where Self: 'a: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn hex_conservative::display::DisplayHex::append_hex_to_string<'a>(&'a self, case: hex_conservative::Case, string: &mut alloc::string::String)
+pub fn hex_conservative::display::DisplayHex::as_hex<'a>(&'a self) -> Self::Display
+pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(&self) -> usize
+pub fn hex_conservative::display::DisplayHex::to_hex_string(&self, case: hex_conservative::Case) -> alloc::string::String
+pub fn hex_conservative::display::DisplayHex::to_lower_hex_string(&self) -> alloc::string::String
+pub fn hex_conservative::display::DisplayHex::to_upper_hex_string(&self) -> alloc::string::String
+impl hex_conservative::display::DisplayHex for [u8]
+pub type [u8]::Display<'a> = hex_conservative::display::DisplayByteSlice<'a>
+pub fn [u8]::as_hex<'a>(&'a self) -> Self::Display
+pub fn [u8]::hex_reserve_suggestion(&self) -> usize
 pub mod hex_conservative::error
 pub enum hex_conservative::error::DecodeFixedLengthBytesError
 pub hex_conservative::error::DecodeFixedLengthBytesError::InvalidChar(hex_conservative::error::InvalidCharError)
@@ -490,130 +344,18 @@ pub unsafe fn hex_conservative::error::OddLengthStringError::clone_to_uninit(&se
 impl<T> core::convert::From<T> for hex_conservative::error::OddLengthStringError
 pub fn hex_conservative::error::OddLengthStringError::from(t: T) -> T
 pub mod hex_conservative::prelude
-pub trait hex_conservative::prelude::DisplayHex: core::marker::Copy + hex_conservative::display::sealed::IsRef + hex_conservative::display::sealed::Sealed
-pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
-pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
-pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::prelude::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
-pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1024]
-pub type &'a [u8; 1024]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1024]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 10]
-pub type &'a [u8; 10]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 10]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 11]
-pub type &'a [u8; 11]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 11]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 128]
-pub type &'a [u8; 128]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 128]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 12]
-pub type &'a [u8; 12]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 12]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 13]
-pub type &'a [u8; 13]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 13]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 14]
-pub type &'a [u8; 14]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 14]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 15]
-pub type &'a [u8; 15]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 15]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 16]
-pub type &'a [u8; 16]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 16]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1]
-pub type &'a [u8; 1]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2048]
-pub type &'a [u8; 2048]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2048]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 20]
-pub type &'a [u8; 20]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 20]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 256]
-pub type &'a [u8; 256]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 256]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2]
-pub type &'a [u8; 2]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 32]
-pub type &'a [u8; 32]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 32]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 33]
-pub type &'a [u8; 33]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 33]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 3]
-pub type &'a [u8; 3]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 3]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4096]
-pub type &'a [u8; 4096]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4096]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4]
-pub type &'a [u8; 4]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 512]
-pub type &'a [u8; 512]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 512]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 5]
-pub type &'a [u8; 5]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 5]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 64]
-pub type &'a [u8; 64]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 64]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 65]
-pub type &'a [u8; 65]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 65]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 6]
-pub type &'a [u8; 6]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 6]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
-pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 7]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
-pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
-pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 9]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
-pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a [u8]::as_hex(self) -> Self::Display
-pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
-pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
-pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
+pub trait hex_conservative::prelude::DisplayHex
+pub type hex_conservative::prelude::DisplayHex::Display<'a> where Self: 'a: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn hex_conservative::prelude::DisplayHex::append_hex_to_string<'a>(&'a self, case: hex_conservative::Case, string: &mut alloc::string::String)
+pub fn hex_conservative::prelude::DisplayHex::as_hex<'a>(&'a self) -> Self::Display
+pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(&self) -> usize
+pub fn hex_conservative::prelude::DisplayHex::to_hex_string(&self, case: hex_conservative::Case) -> alloc::string::String
+pub fn hex_conservative::prelude::DisplayHex::to_lower_hex_string(&self) -> alloc::string::String
+pub fn hex_conservative::prelude::DisplayHex::to_upper_hex_string(&self) -> alloc::string::String
+impl hex_conservative::display::DisplayHex for [u8]
+pub type [u8]::Display<'a> = hex_conservative::display::DisplayByteSlice<'a>
+pub fn [u8]::as_hex<'a>(&'a self) -> Self::Display
+pub fn [u8]::hex_reserve_suggestion(&self) -> usize
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::hex!
 pub macro hex_conservative::impl_fmt_traits!
@@ -1041,129 +783,17 @@ impl<T> core::clone::CloneToUninit for hex_conservative::error::OddLengthStringE
 pub unsafe fn hex_conservative::error::OddLengthStringError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::error::OddLengthStringError
 pub fn hex_conservative::error::OddLengthStringError::from(t: T) -> T
-pub trait hex_conservative::DisplayHex: core::marker::Copy + hex_conservative::display::sealed::IsRef + hex_conservative::display::sealed::Sealed
-pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub fn hex_conservative::DisplayHex::append_hex_to_string(self, case: hex_conservative::Case, string: &mut alloc::string::String)
-pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
-pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
-pub fn hex_conservative::DisplayHex::to_hex_string(self, case: hex_conservative::Case) -> alloc::string::String
-pub fn hex_conservative::DisplayHex::to_lower_hex_string(self) -> alloc::string::String
-pub fn hex_conservative::DisplayHex::to_upper_hex_string(self) -> alloc::string::String
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1024]
-pub type &'a [u8; 1024]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1024]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 10]
-pub type &'a [u8; 10]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 10]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 11]
-pub type &'a [u8; 11]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 11]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 128]
-pub type &'a [u8; 128]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 128]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 12]
-pub type &'a [u8; 12]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 12]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 13]
-pub type &'a [u8; 13]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 13]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 14]
-pub type &'a [u8; 14]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 14]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 15]
-pub type &'a [u8; 15]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 15]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 16]
-pub type &'a [u8; 16]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 16]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1]
-pub type &'a [u8; 1]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2048]
-pub type &'a [u8; 2048]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2048]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 20]
-pub type &'a [u8; 20]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 20]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 256]
-pub type &'a [u8; 256]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 256]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2]
-pub type &'a [u8; 2]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 32]
-pub type &'a [u8; 32]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 32]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 33]
-pub type &'a [u8; 33]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 33]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 3]
-pub type &'a [u8; 3]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 3]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4096]
-pub type &'a [u8; 4096]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4096]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4]
-pub type &'a [u8; 4]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 512]
-pub type &'a [u8; 512]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 512]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 5]
-pub type &'a [u8; 5]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 5]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 64]
-pub type &'a [u8; 64]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 64]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 65]
-pub type &'a [u8; 65]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 65]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 6]
-pub type &'a [u8; 6]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 6]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
-pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 7]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
-pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
-pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 9]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
-pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a [u8]::as_hex(self) -> Self::Display
-pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a alloc::vec::Vec<u8>
-pub type &'a alloc::vec::Vec<u8>::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a alloc::vec::Vec<u8>::as_hex(self) -> Self::Display
-pub fn &'a alloc::vec::Vec<u8>::hex_reserve_suggestion(self) -> usize
+pub trait hex_conservative::DisplayHex
+pub type hex_conservative::DisplayHex::Display<'a> where Self: 'a: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn hex_conservative::DisplayHex::append_hex_to_string<'a>(&'a self, case: hex_conservative::Case, string: &mut alloc::string::String)
+pub fn hex_conservative::DisplayHex::as_hex<'a>(&'a self) -> Self::Display
+pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(&self) -> usize
+pub fn hex_conservative::DisplayHex::to_hex_string(&self, case: hex_conservative::Case) -> alloc::string::String
+pub fn hex_conservative::DisplayHex::to_lower_hex_string(&self) -> alloc::string::String
+pub fn hex_conservative::DisplayHex::to_upper_hex_string(&self) -> alloc::string::String
+impl hex_conservative::display::DisplayHex for [u8]
+pub type [u8]::Display<'a> = hex_conservative::display::DisplayByteSlice<'a>
+pub fn [u8]::as_hex<'a>(&'a self) -> Self::Display
+pub fn [u8]::hex_reserve_suggestion(&self) -> usize
 pub fn hex_conservative::decode_to_array<const N: usize>(hex: &str) -> core::result::Result<[u8; N], hex_conservative::error::DecodeFixedLengthBytesError>
 pub fn hex_conservative::decode_to_vec(hex: &str) -> core::result::Result<alloc::vec::Vec<u8>, hex_conservative::error::DecodeVariableLengthBytesError>

--- a/api/no-features.txt
+++ b/api/no-features.txt
@@ -44,38 +44,6 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::from(t: T) -> T
 pub mod hex_conservative::display
 pub macro hex_conservative::display::fmt_hex_exact!
 pub macro hex_conservative::display::impl_fmt_traits!
-pub struct hex_conservative::display::DisplayArray<'a, const CAP: usize>
-impl<const LEN: usize> core::fmt::Debug for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<const LEN: usize> core::fmt::Display for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<const LEN: usize> core::fmt::LowerHex for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<const LEN: usize> core::fmt::UpperHex for hex_conservative::display::DisplayArray<'_, LEN>
-pub fn hex_conservative::display::DisplayArray<'_, LEN>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<'a, const CAP: usize> core::marker::Freeze for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::Send for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::Sync for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::Unpin for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::marker::UnsafeUnpin for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::panic::unwind_safe::RefUnwindSafe for hex_conservative::display::DisplayArray<'a, CAP>
-impl<'a, const CAP: usize> core::panic::unwind_safe::UnwindSafe for hex_conservative::display::DisplayArray<'a, CAP>
-impl<T, U> core::convert::Into<U> for hex_conservative::display::DisplayArray<'a, CAP> where U: core::convert::From<T>
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for hex_conservative::display::DisplayArray<'a, CAP> where U: core::convert::Into<T>
-pub type hex_conservative::display::DisplayArray<'a, CAP>::Error = core::convert::Infallible
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for hex_conservative::display::DisplayArray<'a, CAP> where U: core::convert::TryFrom<T>
-pub type hex_conservative::display::DisplayArray<'a, CAP>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for hex_conservative::display::DisplayArray<'a, CAP> where T: 'static + ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for hex_conservative::display::DisplayArray<'a, CAP> where T: ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for hex_conservative::display::DisplayArray<'a, CAP> where T: ?core::marker::Sized
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for hex_conservative::display::DisplayArray<'a, CAP>
-pub fn hex_conservative::display::DisplayArray<'a, CAP>::from(t: T) -> T
 pub struct hex_conservative::display::DisplayByteSlice<'a>
 impl core::fmt::Debug for hex_conservative::display::DisplayByteSlice<'_>
 pub fn hex_conservative::display::DisplayByteSlice<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -108,122 +76,14 @@ impl<T> core::borrow::BorrowMut<T> for hex_conservative::display::DisplayByteSli
 pub fn hex_conservative::display::DisplayByteSlice<'a>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for hex_conservative::display::DisplayByteSlice<'a>
 pub fn hex_conservative::display::DisplayByteSlice<'a>::from(t: T) -> T
-pub trait hex_conservative::display::DisplayHex: core::marker::Copy + hex_conservative::display::sealed::IsRef + hex_conservative::display::sealed::Sealed
-pub type hex_conservative::display::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub fn hex_conservative::display::DisplayHex::as_hex(self) -> Self::Display
-pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1024]
-pub type &'a [u8; 1024]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1024]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 10]
-pub type &'a [u8; 10]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 10]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 11]
-pub type &'a [u8; 11]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 11]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 128]
-pub type &'a [u8; 128]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 128]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 12]
-pub type &'a [u8; 12]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 12]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 13]
-pub type &'a [u8; 13]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 13]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 14]
-pub type &'a [u8; 14]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 14]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 15]
-pub type &'a [u8; 15]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 15]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 16]
-pub type &'a [u8; 16]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 16]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1]
-pub type &'a [u8; 1]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2048]
-pub type &'a [u8; 2048]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2048]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 20]
-pub type &'a [u8; 20]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 20]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 256]
-pub type &'a [u8; 256]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 256]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2]
-pub type &'a [u8; 2]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 32]
-pub type &'a [u8; 32]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 32]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 33]
-pub type &'a [u8; 33]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 33]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 3]
-pub type &'a [u8; 3]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 3]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4096]
-pub type &'a [u8; 4096]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4096]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4]
-pub type &'a [u8; 4]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 512]
-pub type &'a [u8; 512]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 512]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 5]
-pub type &'a [u8; 5]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 5]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 64]
-pub type &'a [u8; 64]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 64]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 65]
-pub type &'a [u8; 65]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 65]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 6]
-pub type &'a [u8; 6]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 6]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
-pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 7]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
-pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
-pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 9]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
-pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a [u8]::as_hex(self) -> Self::Display
-pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
+pub trait hex_conservative::display::DisplayHex
+pub type hex_conservative::display::DisplayHex::Display<'a> where Self: 'a: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn hex_conservative::display::DisplayHex::as_hex<'a>(&'a self) -> Self::Display
+pub fn hex_conservative::display::DisplayHex::hex_reserve_suggestion(&self) -> usize
+impl hex_conservative::display::DisplayHex for [u8]
+pub type [u8]::Display<'a> = hex_conservative::display::DisplayByteSlice<'a>
+pub fn [u8]::as_hex<'a>(&'a self) -> Self::Display
+pub fn [u8]::hex_reserve_suggestion(&self) -> usize
 pub mod hex_conservative::error
 pub enum hex_conservative::error::DecodeFixedLengthBytesError
 pub hex_conservative::error::DecodeFixedLengthBytesError::InvalidChar(hex_conservative::error::InvalidCharError)
@@ -448,122 +308,14 @@ pub unsafe fn hex_conservative::error::OddLengthStringError::clone_to_uninit(&se
 impl<T> core::convert::From<T> for hex_conservative::error::OddLengthStringError
 pub fn hex_conservative::error::OddLengthStringError::from(t: T) -> T
 pub mod hex_conservative::prelude
-pub trait hex_conservative::prelude::DisplayHex: core::marker::Copy + hex_conservative::display::sealed::IsRef + hex_conservative::display::sealed::Sealed
-pub type hex_conservative::prelude::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub fn hex_conservative::prelude::DisplayHex::as_hex(self) -> Self::Display
-pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1024]
-pub type &'a [u8; 1024]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1024]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 10]
-pub type &'a [u8; 10]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 10]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 11]
-pub type &'a [u8; 11]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 11]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 128]
-pub type &'a [u8; 128]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 128]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 12]
-pub type &'a [u8; 12]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 12]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 13]
-pub type &'a [u8; 13]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 13]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 14]
-pub type &'a [u8; 14]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 14]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 15]
-pub type &'a [u8; 15]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 15]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 16]
-pub type &'a [u8; 16]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 16]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1]
-pub type &'a [u8; 1]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2048]
-pub type &'a [u8; 2048]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2048]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 20]
-pub type &'a [u8; 20]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 20]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 256]
-pub type &'a [u8; 256]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 256]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2]
-pub type &'a [u8; 2]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 32]
-pub type &'a [u8; 32]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 32]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 33]
-pub type &'a [u8; 33]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 33]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 3]
-pub type &'a [u8; 3]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 3]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4096]
-pub type &'a [u8; 4096]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4096]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4]
-pub type &'a [u8; 4]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 512]
-pub type &'a [u8; 512]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 512]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 5]
-pub type &'a [u8; 5]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 5]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 64]
-pub type &'a [u8; 64]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 64]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 65]
-pub type &'a [u8; 65]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 65]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 6]
-pub type &'a [u8; 6]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 6]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
-pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 7]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
-pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
-pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 9]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
-pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a [u8]::as_hex(self) -> Self::Display
-pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
+pub trait hex_conservative::prelude::DisplayHex
+pub type hex_conservative::prelude::DisplayHex::Display<'a> where Self: 'a: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn hex_conservative::prelude::DisplayHex::as_hex<'a>(&'a self) -> Self::Display
+pub fn hex_conservative::prelude::DisplayHex::hex_reserve_suggestion(&self) -> usize
+impl hex_conservative::display::DisplayHex for [u8]
+pub type [u8]::Display<'a> = hex_conservative::display::DisplayByteSlice<'a>
+pub fn [u8]::as_hex<'a>(&'a self) -> Self::Display
+pub fn [u8]::hex_reserve_suggestion(&self) -> usize
 pub macro hex_conservative::fmt_hex_exact!
 pub macro hex_conservative::hex!
 pub macro hex_conservative::impl_fmt_traits!
@@ -957,120 +709,12 @@ impl<T> core::clone::CloneToUninit for hex_conservative::error::OddLengthStringE
 pub unsafe fn hex_conservative::error::OddLengthStringError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::error::OddLengthStringError
 pub fn hex_conservative::error::OddLengthStringError::from(t: T) -> T
-pub trait hex_conservative::DisplayHex: core::marker::Copy + hex_conservative::display::sealed::IsRef + hex_conservative::display::sealed::Sealed
-pub type hex_conservative::DisplayHex::Display: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
-pub fn hex_conservative::DisplayHex::as_hex(self) -> Self::Display
-pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1024]
-pub type &'a [u8; 1024]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1024]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1024]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 10]
-pub type &'a [u8; 10]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 10]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 10]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 11]
-pub type &'a [u8; 11]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 11]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 11]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 128]
-pub type &'a [u8; 128]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 128]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 128]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 12]
-pub type &'a [u8; 12]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 12]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 12]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 13]
-pub type &'a [u8; 13]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 13]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 13]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 14]
-pub type &'a [u8; 14]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 14]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 14]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 15]
-pub type &'a [u8; 15]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 15]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 15]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 16]
-pub type &'a [u8; 16]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 16]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 16]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 1]
-pub type &'a [u8; 1]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 1]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 1]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2048]
-pub type &'a [u8; 2048]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2048]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2048]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 20]
-pub type &'a [u8; 20]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 20]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 20]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 256]
-pub type &'a [u8; 256]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 256]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 256]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 2]
-pub type &'a [u8; 2]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 2]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 2]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 32]
-pub type &'a [u8; 32]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 32]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 32]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 33]
-pub type &'a [u8; 33]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 33]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 33]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 3]
-pub type &'a [u8; 3]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 3]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 3]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4096]
-pub type &'a [u8; 4096]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4096]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4096]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 4]
-pub type &'a [u8; 4]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 4]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 4]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 512]
-pub type &'a [u8; 512]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 512]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 512]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 5]
-pub type &'a [u8; 5]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 5]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 5]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 64]
-pub type &'a [u8; 64]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 64]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 64]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 65]
-pub type &'a [u8; 65]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 65]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 65]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 6]
-pub type &'a [u8; 6]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 6]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 6]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 7]
-pub type &'a [u8; 7]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 7]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 7]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 8]
-pub type &'a [u8; 8]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 8]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 8]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8; 9]
-pub type &'a [u8; 9]::Display = hex_conservative::display::DisplayArray<'a, {$len * 2}>
-pub fn &'a [u8; 9]::as_hex(self) -> Self::Display
-pub fn &'a [u8; 9]::hex_reserve_suggestion(self) -> usize
-impl<'a> hex_conservative::display::DisplayHex for &'a [u8]
-pub type &'a [u8]::Display = hex_conservative::display::DisplayByteSlice<'a>
-pub fn &'a [u8]::as_hex(self) -> Self::Display
-pub fn &'a [u8]::hex_reserve_suggestion(self) -> usize
+pub trait hex_conservative::DisplayHex
+pub type hex_conservative::DisplayHex::Display<'a> where Self: 'a: core::fmt::Display + core::fmt::Debug + core::fmt::LowerHex + core::fmt::UpperHex
+pub fn hex_conservative::DisplayHex::as_hex<'a>(&'a self) -> Self::Display
+pub fn hex_conservative::DisplayHex::hex_reserve_suggestion(&self) -> usize
+impl hex_conservative::display::DisplayHex for [u8]
+pub type [u8]::Display<'a> = hex_conservative::display::DisplayByteSlice<'a>
+pub fn [u8]::as_hex<'a>(&'a self) -> Self::Display
+pub fn [u8]::hex_reserve_suggestion(&self) -> usize
 pub fn hex_conservative::decode_to_array<const N: usize>(hex: &str) -> core::result::Result<[u8; N], hex_conservative::error::DecodeFixedLengthBytesError>

--- a/src/display.rs
+++ b/src/display.rs
@@ -39,18 +39,16 @@ use crate::buf_encoder::BufEncoder;
 ///
 /// Types that have a single, obvious text representation being hex should **not** implement this
 /// trait and simply implement `Display` instead.
-///
-/// This trait should be generally implemented for references only. We would prefer to use GAT but
-/// that is beyond our MSRV. As a lint we require the `IsRef` trait which is implemented for all
-/// references.
-pub trait DisplayHex: Copy + sealed::IsRef + sealed::Sealed {
+pub trait DisplayHex: sealed::Sealed {
     /// The type providing [`fmt::Display`] implementation.
     ///
-    /// This is usually a wrapper type holding a reference to `Self`.
-    type Display: fmt::Display + fmt::Debug + fmt::LowerHex + fmt::UpperHex;
+    /// This is a wrapper type holding a reference to `Self`.
+    type Display<'a>: fmt::Display + fmt::Debug + fmt::LowerHex + fmt::UpperHex
+    where
+        Self: 'a;
 
     /// Display `Self` as a continuous sequence of ASCII hex chars.
-    fn as_hex(self) -> Self::Display;
+    fn as_hex<'a>(&'a self) -> Self::Display<'a>;
 
     /// Create a lower-hex-encoded string.
     ///
@@ -59,7 +57,7 @@ pub trait DisplayHex: Copy + sealed::IsRef + sealed::Sealed {
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
     #[inline]
-    fn to_lower_hex_string(self) -> String { self.to_hex_string(Case::Lower) }
+    fn to_lower_hex_string(&self) -> String { self.to_hex_string(Case::Lower) }
 
     /// Create an upper-hex-encoded string.
     ///
@@ -68,13 +66,13 @@ pub trait DisplayHex: Copy + sealed::IsRef + sealed::Sealed {
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
     #[inline]
-    fn to_upper_hex_string(self) -> String { self.to_hex_string(Case::Upper) }
+    fn to_upper_hex_string(&self) -> String { self.to_hex_string(Case::Upper) }
 
     /// Create a hex-encoded string.
     ///
     /// This may be faster than `.display_hex().to_string()` because it uses `reserve_suggestion`.
     #[cfg(feature = "alloc")]
-    fn to_hex_string(self, case: Case) -> String {
+    fn to_hex_string(&self, case: Case) -> String {
         let mut string = String::new();
         self.append_hex_to_string(case, &mut string);
         string
@@ -85,7 +83,7 @@ pub trait DisplayHex: Copy + sealed::IsRef + sealed::Sealed {
     /// This may be faster than `write!(string, "{:x}", self.as_hex())` because it uses
     /// `hex_reserve_sugggestion`.
     #[cfg(feature = "alloc")]
-    fn append_hex_to_string(self, case: Case, string: &mut String) {
+    fn append_hex_to_string<'a>(&'a self, case: Case, string: &mut String) {
         use fmt::Write;
 
         string.reserve(self.hex_reserve_suggestion());
@@ -94,7 +92,7 @@ pub trait DisplayHex: Copy + sealed::IsRef + sealed::Sealed {
             Case::Upper => write!(string, "{:X}", self.as_hex()),
         }
         .unwrap_or_else(|_| {
-            let name = core::any::type_name::<Self::Display>();
+            let name = core::any::type_name::<Self::Display<'a>>();
             // We don't expect `std` to ever be buggy, so the bug is most likely in the `Display`
             // impl of `Self::Display`.
             panic!("The implementation of Display for {} returned an error when it shouldn't", name)
@@ -105,7 +103,7 @@ pub trait DisplayHex: Copy + sealed::IsRef + sealed::Sealed {
     ///
     /// If you don't know you can just return 0 and take the perf hit.
     // We prefix the name with `hex_` to avoid potential collision with other methods.
-    fn hex_reserve_suggestion(self) -> usize;
+    fn hex_reserve_suggestion(&self) -> usize;
 }
 
 fn internal_display(bytes: &[u8], f: &mut fmt::Formatter, case: Case) -> fmt::Result {
@@ -206,23 +204,18 @@ fn write_pad_right(
 }
 
 mod sealed {
-    /// Trait marking a shared reference.
-    pub trait IsRef: Copy {}
-
-    impl<T: ?Sized> IsRef for &'_ T {}
-
     /// Used to seal the `DisplayHex` trait.
     pub trait Sealed {}
 
-    impl Sealed for &'_ [u8] {}
+    impl Sealed for [u8] {}
 
     #[cfg(feature = "alloc")]
-    impl Sealed for &'_ alloc::vec::Vec<u8> {}
+    impl Sealed for alloc::vec::Vec<u8> {}
 
     macro_rules! impl_array_sealed {
         ($($len:expr),*) => {
             $(
-                impl<'a> Sealed for &'a [u8; $len] {}
+                impl Sealed for [u8; $len] {}
             )*
         }
     }
@@ -235,14 +228,14 @@ mod sealed {
     );
 }
 
-impl<'a> DisplayHex for &'a [u8] {
-    type Display = DisplayByteSlice<'a>;
+impl DisplayHex for [u8] {
+    type Display<'a> = DisplayByteSlice<'a>;
 
     #[inline]
-    fn as_hex(self) -> Self::Display { DisplayByteSlice { bytes: self } }
+    fn as_hex<'a>(&'a self) -> Self::Display<'a> { DisplayByteSlice { bytes: self } }
 
     #[inline]
-    fn hex_reserve_suggestion(self) -> usize {
+    fn hex_reserve_suggestion(&self) -> usize {
         // Since the string wouldn't fit into address space if this overflows (actually even for
         // smaller amounts) it's better to panic right away. It should also give the optimizer
         // better opportunities.
@@ -251,14 +244,14 @@ impl<'a> DisplayHex for &'a [u8] {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> DisplayHex for &'a alloc::vec::Vec<u8> {
-    type Display = DisplayByteSlice<'a>;
+impl DisplayHex for alloc::vec::Vec<u8> {
+    type Display<'a> = DisplayByteSlice<'a>;
 
     #[inline]
-    fn as_hex(self) -> Self::Display { DisplayByteSlice { bytes: self } }
+    fn as_hex<'a>(&'a self) -> Self::Display<'a> { DisplayByteSlice { bytes: self } }
 
     #[inline]
-    fn hex_reserve_suggestion(self) -> usize {
+    fn hex_reserve_suggestion(&self) -> usize {
         // Since the string wouldn't fit into address space if this overflows (actually even for
         // smaller amounts) it's better to panic right away. It should also give the optimizer
         // better opportunities.
@@ -349,14 +342,14 @@ impl<const LEN: usize> fmt::UpperHex for DisplayArray<'_, LEN> {
 macro_rules! impl_array_as_hex {
     ($($len:expr),*) => {
         $(
-            impl<'a> DisplayHex for &'a [u8; $len] {
-                type Display = DisplayArray<'a, {$len * 2}>;
+            impl DisplayHex for [u8; $len] {
+                type Display<'a> = DisplayArray<'a, {$len * 2}>;
 
-                fn as_hex(self) -> Self::Display {
+                fn as_hex<'a>(&'a self) -> Self::Display<'a> {
                     DisplayArray::new(self)
                 }
 
-                fn hex_reserve_suggestion(self) -> usize { $len * 2 }
+                fn hex_reserve_suggestion(&self) -> usize { $len * 2 }
             }
         )*
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -39,7 +39,7 @@ use crate::buf_encoder::BufEncoder;
 ///
 /// Types that have a single, obvious text representation being hex should **not** implement this
 /// trait and simply implement `Display` instead.
-pub trait DisplayHex: sealed::Sealed {
+pub trait DisplayHex {
     /// The type providing [`fmt::Display`] implementation.
     ///
     /// This is a wrapper type holding a reference to `Self`.
@@ -203,48 +203,7 @@ fn write_pad_right(
     Ok(())
 }
 
-mod sealed {
-    /// Used to seal the `DisplayHex` trait.
-    pub trait Sealed {}
-
-    impl Sealed for [u8] {}
-
-    #[cfg(feature = "alloc")]
-    impl Sealed for alloc::vec::Vec<u8> {}
-
-    macro_rules! impl_array_sealed {
-        ($($len:expr),*) => {
-            $(
-                impl Sealed for [u8; $len] {}
-            )*
-        }
-    }
-
-    // Same as call to `impl_array_as_hex` below.
-    #[rustfmt::skip]
-    impl_array_sealed!(
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 32, 33, 64, 65,
-        128, 256, 512, 1024, 2048, 4096
-    );
-}
-
 impl DisplayHex for [u8] {
-    type Display<'a> = DisplayByteSlice<'a>;
-
-    #[inline]
-    fn as_hex<'a>(&'a self) -> Self::Display<'a> { DisplayByteSlice { bytes: self } }
-
-    #[inline]
-    fn hex_reserve_suggestion(&self) -> usize {
-        // Since the string wouldn't fit into address space if this overflows (actually even for
-        // smaller amounts) it's better to panic right away. It should also give the optimizer
-        // better opportunities.
-        self.len().checked_mul(2).expect("the string wouldn't fit into address space")
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl DisplayHex for alloc::vec::Vec<u8> {
     type Display<'a> = DisplayByteSlice<'a>;
 
     #[inline]
@@ -293,74 +252,6 @@ impl fmt::UpperHex for DisplayByteSlice<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Upper) }
 }
-
-/// Displays byte array as hex.
-///
-/// Created by [`<&[u8; CAP / 2] as DisplayHex>::as_hex`](DisplayHex::as_hex).
-pub struct DisplayArray<'a, const CAP: usize> {
-    array: &'a [u8],
-}
-
-impl<'a, const CAP: usize> DisplayArray<'a, CAP> {
-    /// Creates the wrapper.
-    ///
-    /// # Panics
-    ///
-    /// When the length of array is greater than capacity / 2.
-    #[inline]
-    fn new(array: &'a [u8]) -> Self {
-        assert!(array.len() <= CAP / 2);
-        DisplayArray { array }
-    }
-
-    #[inline]
-    fn display(&self, f: &mut fmt::Formatter, case: Case) -> fmt::Result {
-        internal_display(self.array, f, case)
-    }
-}
-
-impl<const LEN: usize> fmt::Display for DisplayArray<'_, LEN> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
-}
-
-impl<const LEN: usize> fmt::Debug for DisplayArray<'_, LEN> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
-}
-
-impl<const LEN: usize> fmt::LowerHex for DisplayArray<'_, LEN> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Lower) }
-}
-
-impl<const LEN: usize> fmt::UpperHex for DisplayArray<'_, LEN> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.display(f, Case::Upper) }
-}
-
-macro_rules! impl_array_as_hex {
-    ($($len:expr),*) => {
-        $(
-            impl DisplayHex for [u8; $len] {
-                type Display<'a> = DisplayArray<'a, {$len * 2}>;
-
-                fn as_hex<'a>(&'a self) -> Self::Display<'a> {
-                    DisplayArray::new(self)
-                }
-
-                fn hex_reserve_suggestion(&self) -> usize { $len * 2 }
-            }
-        )*
-    }
-}
-
-// Same as call to `impl_array_sealed` above.
-#[rustfmt::skip]
-impl_array_as_hex!(
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 32, 33, 64, 65,
-    128, 256, 512, 1024, 2048, 4096
-);
 
 /// Format known-length array as hex.
 ///

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -49,13 +49,12 @@ where
 {
     a: BytesToHexIter<I>,
     b: buf_encoder::BufEncoder<CAP>,
-    c: display::DisplayArray<'a, CAP>,
-    d: display::DisplayByteSlice<'a>,
+    c: display::DisplayByteSlice<'a>,
     #[cfg(feature = "std")]
-    e: display::HexWriter<T>,
-    f: Case,
-    g: HexToBytesIter<J>,
-    h: HexSliceToBytesIter<'a>,
+    d: display::HexWriter<T>,
+    e: Case,
+    f: HexToBytesIter<J>,
+    g: HexSliceToBytesIter<'a>,
     _marker: PhantomData<T>, // For when `std` is not enabled.
 }
 
@@ -66,13 +65,12 @@ impl Structs<'_, slice::Iter<'_, u8>, core::iter::Copied<slice::Iter<'_, [u8; 2]
         Self {
             a: BytesToHexIter::new(iter, Case::Lower),
             b: buf_encoder::BufEncoder::new(Case::Lower),
-            c: BYTES.as_hex(),
-            d: BYTES[..].as_hex(),
+            c: BYTES[..].as_hex(),
             #[cfg(feature = "std")]
-            e: display::HexWriter::new(String::new(), Case::Lower),
-            f: Case::Lower,
-            g: HexToBytesIter::from_pairs(DIGIT_PAIRS.iter().copied()),
-            h: HexSliceToBytesIter::new(HEX).unwrap(),
+            d: display::HexWriter::new(String::new(), Case::Lower),
+            e: Case::Lower,
+            f: HexToBytesIter::from_pairs(DIGIT_PAIRS.iter().copied()),
+            g: HexSliceToBytesIter::new(HEX).unwrap(),
             _marker: PhantomData,
         }
     }
@@ -103,18 +101,16 @@ fn api_all_non_error_types_have_non_empty_debug() {
     assert!(!debug.is_empty());
     let debug = format!("{:?}", t.c);
     assert!(!debug.is_empty());
-    let debug = format!("{:?}", t.d);
-    assert!(!debug.is_empty());
     #[cfg(feature = "std")]
     {
-        let debug = format!("{:?}", t.e);
+        let debug = format!("{:?}", t.d);
         assert!(!debug.is_empty());
     }
+    let debug = format!("{:?}", t.e);
+    assert!(!debug.is_empty());
     let debug = format!("{:?}", t.f);
     assert!(!debug.is_empty());
     let debug = format!("{:?}", t.g);
-    assert!(!debug.is_empty());
-    let debug = format!("{:?}", t.h);
     assert!(!debug.is_empty());
 }
 


### PR DESCRIPTION
Since it's inception, the DisplayHex trait should ideally have made use of a GAT for the Display associated type. Due to limitations in early Rust versions, this was not possible. By bumping the MSRV to 1.74.0 in the new version of the crate, the DisplayHex trait can now be redesigned using a GAT for the associated Display type. This allows for the function signature of the as_hex to be changed to suit the expected naming convention.

- Patch 1 changes the DisplayHex trait to use a GAT for the Display type, adjusting implementations.
- Patch 2 removes the redundant DisplayHex impls for arrays and Vec. Also removes the DisplayArray type.
- Patch 3 updates the API files.