### PR TITLE
Do not inline error types into docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,11 +117,12 @@ pub(crate) use table::Table;
 #[doc(inline)]
 pub use self::{
     display::DisplayHex,
-    error::{
-        DecodeFixedLengthBytesError, DecodeVariableLengthBytesError, InvalidCharError, InvalidLengthError,
-        OddLengthStringError,
-    },
     iter::{BytesToHexIter, HexToBytesIter, HexSliceToBytesIter},
+};
+#[doc(no_inline)]
+pub use self::error::{
+    DecodeFixedLengthBytesError, DecodeVariableLengthBytesError, InvalidCharError,
+    InvalidLengthError, OddLengthStringError,
 };
 
 /// Decodes a hex string with variable length.


### PR DESCRIPTION
As we have recently started doing in `rust-bitcoin`; do not inline error types because that way the docs render nicely with the errors in a different section to the rest of the public types.
