### PR TITLE
Do trivial error cleanups

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -246,7 +246,10 @@ impl fmt::Display for InvalidCharError {
 }
 
 if_std_error! {{
-    impl StdError for InvalidCharError {}
+    impl StdError for InvalidCharError {
+        #[inline]
+        fn source(&self) -> Option<&(dyn StdError + 'static)> { None }
+    }
 }}
 
 /// Purported hex string had odd length.
@@ -278,7 +281,10 @@ impl fmt::Display for OddLengthStringError {
 }
 
 if_std_error! {{
-    impl StdError for OddLengthStringError {}
+    impl StdError for OddLengthStringError {
+        #[inline]
+        fn source(&self) -> Option<&(dyn StdError + 'static)> { None }
+    }
 }}
 
 /// Error returned when hex decoding bytes whose length is known at compile time.
@@ -403,7 +409,10 @@ impl fmt::Display for InvalidLengthError {
 }
 
 if_std_error! {{
-    impl StdError for InvalidLengthError {}
+    impl StdError for InvalidLengthError {
+        #[inline]
+        fn source(&self) -> Option<&(dyn StdError + 'static)> { None }
+    }
 }}
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,11 +157,6 @@ pub struct InvalidCharError {
     pub(crate) pos: usize,
 }
 
-impl From<Infallible> for InvalidCharError {
-    #[inline]
-    fn from(never: Infallible) -> Self { match never {} }
-}
-
 impl InvalidCharError {
     /// Returns the invalid character byte.
     #[inline]
@@ -193,6 +188,11 @@ impl InvalidCharError {
         self.pos += by_bytes;
         self
     }
+}
+
+impl From<Infallible> for InvalidCharError {
+    #[inline]
+    fn from(never: Infallible) -> Self { match never {} }
 }
 
 /// Note that the implementation displays position as 1-based instead of 0-based to be more
@@ -255,15 +255,15 @@ pub struct OddLengthStringError {
     pub(crate) len: usize,
 }
 
-impl From<Infallible> for OddLengthStringError {
-    #[inline]
-    fn from(never: Infallible) -> Self { match never {} }
-}
-
 impl OddLengthStringError {
     /// Returns the odd length of the input string.
     #[inline]
     pub fn length(&self) -> usize { self.len }
+}
+
+impl From<Infallible> for OddLengthStringError {
+    #[inline]
+    fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for OddLengthStringError {
@@ -369,11 +369,6 @@ pub struct InvalidLengthError {
     pub(crate) invalid: usize,
 }
 
-impl From<Infallible> for InvalidLengthError {
-    #[inline]
-    fn from(never: Infallible) -> Self { match never {} }
-}
-
 impl InvalidLengthError {
     /// Returns the expected length.
     ///
@@ -388,6 +383,11 @@ impl InvalidLengthError {
     /// invalid (wide unicode chars).
     #[inline]
     pub fn invalid_length(&self) -> usize { self.invalid }
+}
+
+impl From<Infallible> for InvalidLengthError {
+    #[inline]
+    fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for InvalidLengthError {


### PR DESCRIPTION
As we just did in `rust-bitcoin` move the `From<Infallible>` impl and be explicit when implementing `error::Error`.