### PR TITLE
Add `FromIterator` and `Extend` to `BufEncoder`

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -10,6 +10,10 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_byte(&mut self, byte:
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes<I>(&mut self, bytes: I) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_min<'a>(&mut self, bytes: &'a [u8]) -> &'a [u8]
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::space_remaining(&self) -> usize
+impl<const CAP: usize, A: core::borrow::Borrow<u8>> core::iter::traits::collect::Extend<A> for hex_conservative::buf_encoder::BufEncoder<CAP>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::extend<T: core::iter::traits::collect::IntoIterator<Item = A>>(&mut self, iter: T)
+impl<const CAP: usize, A: core::borrow::Borrow<u8>> core::iter::traits::collect::FromIterator<A> for hex_conservative::buf_encoder::BufEncoder<CAP>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::from_iter<T: core::iter::traits::collect::IntoIterator<Item = A>>(iter: T) -> Self
 impl<const CAP: usize> core::default::Default for hex_conservative::buf_encoder::BufEncoder<CAP>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
 impl<const CAP: usize> core::fmt::Debug for hex_conservative::buf_encoder::BufEncoder<CAP>

--- a/api/alloc-only.txt
+++ b/api/alloc-only.txt
@@ -10,6 +10,10 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_byte(&mut self, byte:
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes<I>(&mut self, bytes: I) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_min<'a>(&mut self, bytes: &'a [u8]) -> &'a [u8]
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::space_remaining(&self) -> usize
+impl<const CAP: usize, A: core::borrow::Borrow<u8>> core::iter::traits::collect::Extend<A> for hex_conservative::buf_encoder::BufEncoder<CAP>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::extend<T: core::iter::traits::collect::IntoIterator<Item = A>>(&mut self, iter: T)
+impl<const CAP: usize, A: core::borrow::Borrow<u8>> core::iter::traits::collect::FromIterator<A> for hex_conservative::buf_encoder::BufEncoder<CAP>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::from_iter<T: core::iter::traits::collect::IntoIterator<Item = A>>(iter: T) -> Self
 impl<const CAP: usize> core::default::Default for hex_conservative::buf_encoder::BufEncoder<CAP>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
 impl<const CAP: usize> core::fmt::Debug for hex_conservative::buf_encoder::BufEncoder<CAP>

--- a/api/no-features.txt
+++ b/api/no-features.txt
@@ -10,6 +10,10 @@ pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_byte(&mut self, byte:
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes<I>(&mut self, bytes: I) where I: core::iter::traits::collect::IntoIterator, <I as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::put_bytes_min<'a>(&mut self, bytes: &'a [u8]) -> &'a [u8]
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::space_remaining(&self) -> usize
+impl<const CAP: usize, A: core::borrow::Borrow<u8>> core::iter::traits::collect::Extend<A> for hex_conservative::buf_encoder::BufEncoder<CAP>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::extend<T: core::iter::traits::collect::IntoIterator<Item = A>>(&mut self, iter: T)
+impl<const CAP: usize, A: core::borrow::Borrow<u8>> core::iter::traits::collect::FromIterator<A> for hex_conservative::buf_encoder::BufEncoder<CAP>
+pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::from_iter<T: core::iter::traits::collect::IntoIterator<Item = A>>(iter: T) -> Self
 impl<const CAP: usize> core::default::Default for hex_conservative::buf_encoder::BufEncoder<CAP>
 pub fn hex_conservative::buf_encoder::BufEncoder<CAP>::default() -> Self
 impl<const CAP: usize> core::fmt::Debug for hex_conservative::buf_encoder::BufEncoder<CAP>

--- a/src/buf_encoder.rs
+++ b/src/buf_encoder.rs
@@ -148,6 +148,18 @@ impl<const CAP: usize> Default for BufEncoder<CAP> {
     fn default() -> Self { Self::new(Case::Lower) }
 }
 
+impl<const CAP: usize, A: Borrow<u8>> FromIterator<A> for BufEncoder<CAP> {
+    fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
+        let mut encoder = Self::default();
+        encoder.put_bytes(iter);
+        encoder
+    }
+}
+
+impl<const CAP: usize, A: Borrow<u8>> Extend<A> for BufEncoder<CAP> {
+    fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T) { self.put_bytes(iter); }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,6 +274,29 @@ mod tests {
         assert_eq!(encoder.as_str(), "aéé");
         assert_eq!(encoder.put_filler('é', 4), 1); // Try to fill more than fits
         assert_eq!(encoder.as_str(), "aééé");
+    }
+
+    #[test]
+    fn from_iterator() {
+        let bytes = [0x00_u8, 0xab, 0xff];
+        let encoder: BufEncoder<6> = bytes.iter().collect(); // ref iter
+        assert_eq!(encoder.as_str(), "00abff");
+
+        let encoder: BufEncoder<6> = bytes.into_iter().collect(); // owned iter
+        assert_eq!(encoder.as_str(), "00abff");
+    }
+
+    #[test]
+    fn extend() {
+        let mut encoder = BufEncoder::<8>::new(Case::Upper);
+        encoder.put_byte(0x00);
+        encoder.extend([0xab_u8, 0xff]);
+        assert_eq!(encoder.as_str(), "00ABFF");
+
+        let mut encoder = BufEncoder::<6>::new(Case::Lower);
+        encoder.put_byte(0x42);
+        encoder.extend([0xab_u8, 0xff]);
+        assert_eq!(encoder.as_str(), "42abff");
     }
 
     #[test]


### PR DESCRIPTION
The BufEncoder type represents a collection of bytes. According to the C-COLLECT API guideline, collections should implement FromIterator and Extend in order to allow for simple construction using functions like collect() on iterators.

Implement FromIterator and Extend on BufEncoder.