### PR TITLE
CI: Add api job

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [lint, docs, docsrs, "fmt --check"]
+        task: [api, lint, docs, docsrs, "fmt --check"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
I thought it might be better not to do this in order to not slow us down and cause rebases and I'm still not 100% what is better.

Elect to take the safe but possibly annoying route and enable the job.