### PR TITLE
Implement `nth` and `nth_back`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["api", "tests", "contrib"]
 
 [workspace]
 members = ["fuzz"]
+exclude = ["benches"]
 
 [features]
 default = ["std"]

--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -819,11 +819,13 @@ impl<I> core::fmt::Debug for hex_conservative::BytesToHexIter<I> where I: core::
 pub fn hex_conservative::BytesToHexIter<I>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::next_back(&mut self) -> core::option::Option<char>
+pub fn hex_conservative::BytesToHexIter<I>::nth_back(&mut self, n: usize) -> core::option::Option<char>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
+pub fn hex_conservative::BytesToHexIter<I>::nth(&mut self, n: usize) -> core::option::Option<char>
 pub fn hex_conservative::BytesToHexIter<I>::size_hint(&self) -> (usize, core::option::Option<usize>)
 impl<I> core::iter::traits::marker::FusedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::marker::FusedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 impl<I> core::marker::Freeze for hex_conservative::BytesToHexIter<I> where I: core::marker::Freeze

--- a/api/alloc-only.txt
+++ b/api/alloc-only.txt
@@ -773,11 +773,13 @@ impl<I> core::fmt::Debug for hex_conservative::BytesToHexIter<I> where I: core::
 pub fn hex_conservative::BytesToHexIter<I>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::next_back(&mut self) -> core::option::Option<char>
+pub fn hex_conservative::BytesToHexIter<I>::nth_back(&mut self, n: usize) -> core::option::Option<char>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
+pub fn hex_conservative::BytesToHexIter<I>::nth(&mut self, n: usize) -> core::option::Option<char>
 pub fn hex_conservative::BytesToHexIter<I>::size_hint(&self) -> (usize, core::option::Option<usize>)
 impl<I> core::iter::traits::marker::FusedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::marker::FusedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 impl<I> core::marker::Freeze for hex_conservative::BytesToHexIter<I> where I: core::marker::Freeze

--- a/api/no-features.txt
+++ b/api/no-features.txt
@@ -707,11 +707,13 @@ impl<I> core::fmt::Debug for hex_conservative::BytesToHexIter<I> where I: core::
 pub fn hex_conservative::BytesToHexIter<I>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::next_back(&mut self) -> core::option::Option<char>
+pub fn hex_conservative::BytesToHexIter<I>::nth_back(&mut self, n: usize) -> core::option::Option<char>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub type hex_conservative::BytesToHexIter<I>::Item = char
 pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
+pub fn hex_conservative::BytesToHexIter<I>::nth(&mut self, n: usize) -> core::option::Option<char>
 pub fn hex_conservative::BytesToHexIter<I>::size_hint(&self) -> (usize, core::option::Option<usize>)
 impl<I> core::iter::traits::marker::FusedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::marker::FusedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 impl<I> core::marker::Freeze for hex_conservative::BytesToHexIter<I> where I: core::marker::Freeze

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,17 @@
+ [package]
+ name = "hex-conservative-benches"
+ version = "0.1.0"
+ license = "CC0-1.0"
+ description = "Criterion benchmarks for hex-conservative"
+ edition = "2021"
+ rust-version = "1.81"
+
+ [dependencies]
+ criterion = "0.7"
+ hex-conservative = { path = "..", default-features = false, features = ["std"] }
+
+ [[bench]]
+ name = "iter"
+ path = "hex/iter.rs"
+ harness = false
+ 

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,41 @@
+ # Hex Conservative Benchmarks
+
+ Criterion based benchmarks for `hex-conservative`.
+
+ ## Minimum Supported Rust Version (MSRV)
+
+ This crate's MSRV is determined by its Criterion dependency. It currently requires **Rust 1.81**.
+ This higher MSRV applies only to the benches crate and does not affect the main crate.
+
+ ## Running the benchmarks
+
+ Examples below are run from within the crate folder `benches/`, if running from the repo root pass in `--manifest-path benches/Cargo.toml`.
+
+ Run all benchmarks in this crate:
+
+ ```bash
+ cargo bench
+ ```
+
+ Run the iterator benchmark target:
+
+ ```bash
+ cargo bench --bench iter
+ ```
+
+ Pass options through to Criterion:
+
+ ```bash
+ cargo bench --bench iter -- --save-baseline before-change
+ cargo bench --bench iter -- --baseline before-change
+ ```
+
+ View reports:
+
+ - Criterion writes detailed html reports that are linked to in `target/criterion/report/index.html`.
+
+ ## Licensing
+
+ The code in this project is licensed under the [Creative Commons CC0 1.0 Universal license](../LICENSE).
+ We use the [SPDX license list](https://spdx.org/licenses/) and [SPDX IDs](https://spdx.dev/ids/).
+ 

--- a/benches/hex/iter.rs
+++ b/benches/hex/iter.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use hex_conservative::{BytesToHexIter, Case};
+
+fn nth_positions(size: usize) -> [usize; 5] {
+    let total = size * 2;
+    [size / 8, size / 2, size, size + size / 2, total - 1]
+}
+
+fn slow_nth(iter: &mut BytesToHexIter<core::slice::Iter<'_, u8>>, n: usize) -> Option<char> {
+    for _ in 0..n {
+        iter.next()?;
+    }
+    iter.next()
+}
+
+fn slow_nth_back(
+    iter: &mut BytesToHexIter<core::slice::Iter<'_, u8>>,
+    n: usize,
+) -> Option<char> {
+    for _ in 0..n {
+        iter.next_back()?;
+    }
+    iter.next_back()
+}
+
+fn bench_bytes_to_hex_nth(c: &mut Criterion) {
+    let mut g = c.benchmark_group("bytes_to_hex_iter_nth");
+    g.warm_up_time(Duration::from_secs(1)).measurement_time(Duration::from_secs(3));
+
+    for &size in &[128usize, 4096] {
+        let bytes = vec![0x5a; size];
+        let positions = nth_positions(size);
+
+        g.bench_function(BenchmarkId::new("optimized", size), |b| {
+            b.iter(|| {
+                let mut sum = 0u32;
+                for &n in &positions {
+                    let mut iter = BytesToHexIter::new(black_box(bytes.as_slice()).iter(), Case::Lower);
+                    sum += u32::from(iter.nth(black_box(n)).unwrap());
+                }
+                black_box(sum)
+            });
+        });
+
+        g.bench_function(BenchmarkId::new("linear_baseline", size), |b| {
+            b.iter(|| {
+                let mut sum = 0u32;
+                for &n in &positions {
+                    let mut iter = BytesToHexIter::new(black_box(bytes.as_slice()).iter(), Case::Lower);
+                    sum += u32::from(slow_nth(&mut iter, black_box(n)).unwrap());
+                }
+                black_box(sum)
+            });
+        });
+    }
+
+    g.finish();
+}
+
+fn bench_bytes_to_hex_nth_back(c: &mut Criterion) {
+    let mut g = c.benchmark_group("bytes_to_hex_iter_nth_back");
+    g.warm_up_time(Duration::from_secs(1)).measurement_time(Duration::from_secs(3));
+
+    for &size in &[128usize, 4096] {
+        let bytes = vec![0x5a; size];
+        let positions = nth_positions(size);
+
+        g.bench_function(BenchmarkId::new("optimized", size), |b| {
+            b.iter(|| {
+                let mut sum = 0u32;
+                for &n in &positions {
+                    let mut iter = BytesToHexIter::new(black_box(bytes.as_slice()).iter(), Case::Lower);
+                    sum += u32::from(iter.nth_back(black_box(n)).unwrap());
+                }
+                black_box(sum)
+            });
+        });
+
+        g.bench_function(BenchmarkId::new("linear_baseline", size), |b| {
+            b.iter(|| {
+                let mut sum = 0u32;
+                for &n in &positions {
+                    let mut iter = BytesToHexIter::new(black_box(bytes.as_slice()).iter(), Case::Lower);
+                    sum += u32::from(slow_nth_back(&mut iter, black_box(n)).unwrap());
+                }
+                black_box(sum)
+            });
+        });
+    }
+
+    g.finish();
+}
+
+criterion_group!(benches, bench_bytes_to_hex_nth, bench_bytes_to_hex_nth_back);
+criterion_main!(benches);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -310,6 +310,22 @@ where
             None => (min * 2, max.map(|max| max * 2)),
         }
     }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<char> {
+        let had_low = self.low.is_some();
+        if let Some(c) = self.low.take() {
+            if n == 0 {
+                return Some(c);
+            }
+        }
+
+        let n = n - usize::from(had_low);
+        let [high, low] = self.table.byte_to_chars(*self.iter.nth(n / 2)?.borrow());
+        self.low = if n % 2 == 0 { Some(low) } else { None };
+
+        Some(if n % 2 == 0 { high } else { low })
+    }
 }
 
 impl<I> DoubleEndedIterator for BytesToHexIter<I>
@@ -331,6 +347,22 @@ where
             }),
         }
     }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<char> {
+        let had_low = self.low.is_some();
+        if let Some(c) = self.low.take() {
+            if n == 0 {
+                return Some(c);
+            }
+        }
+
+        let n = n - usize::from(had_low);
+        let [high, low] = self.table.byte_to_chars(*self.iter.nth_back(n / 2)?.borrow());
+        self.low = if n % 2 == 0 { Some(low) } else { None };
+
+        Some(if n % 2 == 0 { high } else { low })
+    }
 }
 
 impl<I> ExactSizeIterator for BytesToHexIter<I>
@@ -339,7 +371,7 @@ where
     I::Item: Borrow<u8>,
 {
     #[inline]
-    fn len(&self) -> usize { self.iter.len() * 2 }
+    fn len(&self) -> usize { self.iter.len() * 2 + usize::from(self.low.is_some()) }
 }
 
 impl<I> FusedIterator for BytesToHexIter<I>

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -388,6 +388,20 @@ mod tests {
 
     use super::*;
 
+    fn nth_slow<I: Iterator>(iter: &mut I, n: usize) -> Option<I::Item> {
+        for _ in 0..n {
+            iter.next()?;
+        }
+        iter.next()
+    }
+
+    fn nth_back_slow<I: DoubleEndedIterator>(iter: &mut I, n: usize) -> Option<I::Item> {
+        for _ in 0..n {
+            iter.next_back()?;
+        }
+        iter.next_back()
+    }
+
     #[test]
     fn encode_byte() {
         assert_eq!(Table::LOWER.byte_to_chars(0x00), ['0', '0']);
@@ -606,6 +620,94 @@ mod tests {
         }
         for (i, c) in BytesToHexIter::new(bytes.iter(), Case::Upper).rev().enumerate() {
             assert_eq!(c, upper_want.chars().nth(i).unwrap());
+        }
+    }
+
+    #[test]
+    fn encode_iter_nth() {
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
+
+        for n in 0..=bytes.len() * 2 + 1 {
+            let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
+            let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
+
+            assert_eq!(got.nth(n), nth_slow(&mut want, n));
+            assert_eq!(got.len(), want.len());
+            assert!(got.eq(want));
+        }
+    }
+
+    #[test]
+    fn encode_iter_nth_after_next_back() {
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
+
+        for n in 0..=bytes.len() * 2 {
+            let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
+            let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
+
+            assert_eq!(got.next_back(), want.next_back());
+            assert_eq!(got.nth(n), nth_slow(&mut want, n));
+            assert_eq!(got.len(), want.len());
+            assert!(got.eq(want));
+        }
+    }
+
+    #[test]
+    fn encode_iter_nth_after_next() {
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
+
+        for n in 0..=bytes.len() * 2 {
+            let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
+            let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
+
+            assert_eq!(got.next(), want.next());
+            assert_eq!(got.nth(n), nth_slow(&mut want, n));
+            assert_eq!(got.len(), want.len());
+            assert!(got.eq(want));
+        }
+    }
+
+    #[test]
+    fn encode_iter_nth_back() {
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
+
+        for n in 0..=bytes.len() * 2 + 1 {
+            let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
+            let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
+
+            assert_eq!(got.nth_back(n), nth_back_slow(&mut want, n));
+            assert_eq!(got.len(), want.len());
+            assert!(got.eq(want));
+        }
+    }
+
+    #[test]
+    fn encode_iter_nth_back_after_next() {
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
+
+        for n in 0..=bytes.len() * 2 {
+            let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
+            let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
+
+            assert_eq!(got.next(), want.next());
+            assert_eq!(got.nth_back(n), nth_back_slow(&mut want, n));
+            assert_eq!(got.len(), want.len());
+            assert!(got.eq(want));
+        }
+    }
+
+    #[test]
+    fn encode_iter_nth_back_after_next_back() {
+        let bytes = [0xde, 0xad, 0xbe, 0xef];
+
+        for n in 0..=bytes.len() * 2 {
+            let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
+            let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
+
+            assert_eq!(got.next_back(), want.next_back());
+            assert_eq!(got.nth_back(n), nth_back_slow(&mut want, n));
+            assert_eq!(got.len(), want.len());
+            assert!(got.eq(want));
         }
     }
 


### PR DESCRIPTION
Overriding `nth` and `nth_back` can be O(1) instead of the current O(n).

- Override the default implementations.
- Add tests for the new implementations.
- Add a benches crate with benchmarks comparing the new implementations to the old ones.
- Update API files

Benchmark results:
| Operation | Size (bytes) | Optimized (median) | Linear baseline (median) | Speed increase |
|---|---:|---:|---:|---:|
| BytesToHexIter::nth | 128 | 6.73 ns | 191.05 ns | 28.4× |
| BytesToHexIter::nth | 4096 | 6.57 ns | 5.615 µs | 854.5× |
| BytesToHexIter::nth_back | 128 | 6.94 ns | 163.65 ns | 23.6× |
| BytesToHexIter::nth_back | 4096 | 7.12 ns | 4.754 µs | 667.8× | 

Closes #14