### PR TITLE
Do trivial improvements to API surface test

### DIFF
--- a/tests/api.rs
+++ b/tests/api.rs
@@ -73,11 +73,11 @@ impl Structs<'_, slice::Iter<'_, u8>, String> {
 // These derives are the policy of `rust-bitcoin` not Rust API guidelines.
 #[derive(Debug, Clone, PartialEq, Eq)] // All public types implement Debug (C-DEBUG).
 struct Errors {
-    c: DecodeFixedLengthBytesError,
-    d: DecodeVariableLengthBytesError,
-    e: InvalidCharError,
-    f: InvalidLengthError,
-    g: OddLengthStringError,
+    a: DecodeFixedLengthBytesError,
+    b: DecodeVariableLengthBytesError,
+    c: InvalidCharError,
+    d: InvalidLengthError,
+    e: OddLengthStringError,
 }
 
 // `Debug` representation is never empty (C-DEBUG-NONEMPTY).

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -116,3 +116,12 @@ fn all_types_implement_send_sync() {
     assert_send::<Errors>();
     assert_sync::<Errors>();
 }
+
+// There is a single trait and it is not dyn-compatible.
+#[test]
+fn dyn_compatible() {
+    // If this builds then traits are dyn compatible.
+    struct Traits {
+        // a: Box<dyn hex_conservative::DisplayHex>,
+    }
+}


### PR DESCRIPTION
Just to double check the test I went over it super closely. I'm happy with it _not_ having all the re-export tests that we do over in `units` and `primitives` because I'm starting to think they don't add much value now anyways.

All I found were two trivial improvements. Done to ensure we can check off item in #209 after this and #231 go in.