### PR TITLE
Introduce `Char` enum and rewrite `BytesToHexIter` to return it

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -488,6 +488,77 @@ impl<T> core::clone::CloneToUninit for hex_conservative::Case where T: core::clo
 pub unsafe fn hex_conservative::Case::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::Case
 pub fn hex_conservative::Case::from(t: T) -> T
+#[repr(u8)] pub enum hex_conservative::Char
+pub hex_conservative::Char::Eight = 56
+pub hex_conservative::Char::Five = 53
+pub hex_conservative::Char::Four = 52
+pub hex_conservative::Char::LowerA = 97
+pub hex_conservative::Char::LowerB = 98
+pub hex_conservative::Char::LowerC = 99
+pub hex_conservative::Char::LowerD = 100
+pub hex_conservative::Char::LowerE = 101
+pub hex_conservative::Char::LowerF = 102
+pub hex_conservative::Char::Nine = 57
+pub hex_conservative::Char::One = 49
+pub hex_conservative::Char::Seven = 55
+pub hex_conservative::Char::Six = 54
+pub hex_conservative::Char::Three = 51
+pub hex_conservative::Char::Two = 50
+pub hex_conservative::Char::UpperA = 65
+pub hex_conservative::Char::UpperB = 66
+pub hex_conservative::Char::UpperC = 67
+pub hex_conservative::Char::UpperD = 68
+pub hex_conservative::Char::UpperE = 69
+pub hex_conservative::Char::UpperF = 70
+pub hex_conservative::Char::Zero = 48
+impl core::clone::Clone for hex_conservative::Char
+pub fn hex_conservative::Char::clone(&self) -> hex_conservative::Char
+impl core::cmp::Eq for hex_conservative::Char
+impl core::cmp::Ord for hex_conservative::Char
+pub fn hex_conservative::Char::cmp(&self, other: &hex_conservative::Char) -> core::cmp::Ordering
+impl core::cmp::PartialEq for hex_conservative::Char
+pub fn hex_conservative::Char::eq(&self, other: &hex_conservative::Char) -> bool
+impl core::cmp::PartialOrd for hex_conservative::Char
+pub fn hex_conservative::Char::partial_cmp(&self, other: &hex_conservative::Char) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<hex_conservative::Char> for char
+pub fn char::from(c: hex_conservative::Char) -> char
+impl core::convert::From<hex_conservative::Char> for u8
+pub fn u8::from(c: hex_conservative::Char) -> u8
+impl core::fmt::Debug for hex_conservative::Char
+pub fn hex_conservative::Char::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for hex_conservative::Char
+pub fn hex_conservative::Char::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for hex_conservative::Char
+impl core::marker::StructuralPartialEq for hex_conservative::Char
+impl core::marker::Freeze for hex_conservative::Char
+impl core::marker::Send for hex_conservative::Char
+impl core::marker::Sync for hex_conservative::Char
+impl core::marker::Unpin for hex_conservative::Char
+impl core::marker::UnsafeUnpin for hex_conservative::Char
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Char
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Char
+impl<T, U> core::convert::Into<U> for hex_conservative::Char where U: core::convert::From<T>
+pub fn hex_conservative::Char::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for hex_conservative::Char where U: core::convert::Into<T>
+pub type hex_conservative::Char::Error = core::convert::Infallible
+pub fn hex_conservative::Char::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for hex_conservative::Char where U: core::convert::TryFrom<T>
+pub type hex_conservative::Char::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn hex_conservative::Char::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for hex_conservative::Char where T: core::clone::Clone
+pub type hex_conservative::Char::Owned = T
+pub fn hex_conservative::Char::clone_into(&self, target: &mut T)
+pub fn hex_conservative::Char::to_owned(&self) -> T
+impl<T> core::any::Any for hex_conservative::Char where T: 'static + ?core::marker::Sized
+pub fn hex_conservative::Char::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for hex_conservative::Char where T: ?core::marker::Sized
+pub fn hex_conservative::Char::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for hex_conservative::Char where T: ?core::marker::Sized
+pub fn hex_conservative::Char::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for hex_conservative::Char where T: core::clone::Clone
+pub unsafe fn hex_conservative::Char::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for hex_conservative::Char
+pub fn hex_conservative::Char::from(t: T) -> T
 pub enum hex_conservative::DecodeFixedLengthBytesError
 pub hex_conservative::DecodeFixedLengthBytesError::InvalidChar(hex_conservative::error::InvalidCharError)
 pub hex_conservative::DecodeFixedLengthBytesError::InvalidLength(hex_conservative::error::InvalidLengthError)
@@ -609,14 +680,14 @@ pub fn hex_conservative::BytesToHexIter<I>::fmt(&self, f: &mut core::fmt::Format
 impl<I> core::hash::Hash for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator + core::hash::Hash, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
-pub fn hex_conservative::BytesToHexIter<I>::next_back(&mut self) -> core::option::Option<char>
-pub fn hex_conservative::BytesToHexIter<I>::nth_back(&mut self, n: usize) -> core::option::Option<char>
+pub fn hex_conservative::BytesToHexIter<I>::next_back(&mut self) -> core::option::Option<[hex_conservative::Char; 2]>
+pub fn hex_conservative::BytesToHexIter<I>::nth_back(&mut self, n: usize) -> core::option::Option<[hex_conservative::Char; 2]>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
-pub type hex_conservative::BytesToHexIter<I>::Item = char
-pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
-pub fn hex_conservative::BytesToHexIter<I>::nth(&mut self, n: usize) -> core::option::Option<char>
+pub type hex_conservative::BytesToHexIter<I>::Item = [hex_conservative::Char; 2]
+pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<[hex_conservative::Char; 2]>
+pub fn hex_conservative::BytesToHexIter<I>::nth(&mut self, n: usize) -> core::option::Option<[hex_conservative::Char; 2]>
 pub fn hex_conservative::BytesToHexIter<I>::size_hint(&self) -> (usize, core::option::Option<usize>)
 impl<I> core::iter::traits::marker::FusedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::marker::FusedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 impl<I> core::marker::StructuralPartialEq for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>

--- a/api/alloc-only.txt
+++ b/api/alloc-only.txt
@@ -432,6 +432,77 @@ impl<T> core::clone::CloneToUninit for hex_conservative::Case where T: core::clo
 pub unsafe fn hex_conservative::Case::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::Case
 pub fn hex_conservative::Case::from(t: T) -> T
+#[repr(u8)] pub enum hex_conservative::Char
+pub hex_conservative::Char::Eight = 56
+pub hex_conservative::Char::Five = 53
+pub hex_conservative::Char::Four = 52
+pub hex_conservative::Char::LowerA = 97
+pub hex_conservative::Char::LowerB = 98
+pub hex_conservative::Char::LowerC = 99
+pub hex_conservative::Char::LowerD = 100
+pub hex_conservative::Char::LowerE = 101
+pub hex_conservative::Char::LowerF = 102
+pub hex_conservative::Char::Nine = 57
+pub hex_conservative::Char::One = 49
+pub hex_conservative::Char::Seven = 55
+pub hex_conservative::Char::Six = 54
+pub hex_conservative::Char::Three = 51
+pub hex_conservative::Char::Two = 50
+pub hex_conservative::Char::UpperA = 65
+pub hex_conservative::Char::UpperB = 66
+pub hex_conservative::Char::UpperC = 67
+pub hex_conservative::Char::UpperD = 68
+pub hex_conservative::Char::UpperE = 69
+pub hex_conservative::Char::UpperF = 70
+pub hex_conservative::Char::Zero = 48
+impl core::clone::Clone for hex_conservative::Char
+pub fn hex_conservative::Char::clone(&self) -> hex_conservative::Char
+impl core::cmp::Eq for hex_conservative::Char
+impl core::cmp::Ord for hex_conservative::Char
+pub fn hex_conservative::Char::cmp(&self, other: &hex_conservative::Char) -> core::cmp::Ordering
+impl core::cmp::PartialEq for hex_conservative::Char
+pub fn hex_conservative::Char::eq(&self, other: &hex_conservative::Char) -> bool
+impl core::cmp::PartialOrd for hex_conservative::Char
+pub fn hex_conservative::Char::partial_cmp(&self, other: &hex_conservative::Char) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<hex_conservative::Char> for char
+pub fn char::from(c: hex_conservative::Char) -> char
+impl core::convert::From<hex_conservative::Char> for u8
+pub fn u8::from(c: hex_conservative::Char) -> u8
+impl core::fmt::Debug for hex_conservative::Char
+pub fn hex_conservative::Char::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for hex_conservative::Char
+pub fn hex_conservative::Char::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for hex_conservative::Char
+impl core::marker::StructuralPartialEq for hex_conservative::Char
+impl core::marker::Freeze for hex_conservative::Char
+impl core::marker::Send for hex_conservative::Char
+impl core::marker::Sync for hex_conservative::Char
+impl core::marker::Unpin for hex_conservative::Char
+impl core::marker::UnsafeUnpin for hex_conservative::Char
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Char
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Char
+impl<T, U> core::convert::Into<U> for hex_conservative::Char where U: core::convert::From<T>
+pub fn hex_conservative::Char::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for hex_conservative::Char where U: core::convert::Into<T>
+pub type hex_conservative::Char::Error = core::convert::Infallible
+pub fn hex_conservative::Char::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for hex_conservative::Char where U: core::convert::TryFrom<T>
+pub type hex_conservative::Char::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn hex_conservative::Char::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for hex_conservative::Char where T: core::clone::Clone
+pub type hex_conservative::Char::Owned = T
+pub fn hex_conservative::Char::clone_into(&self, target: &mut T)
+pub fn hex_conservative::Char::to_owned(&self) -> T
+impl<T> core::any::Any for hex_conservative::Char where T: 'static + ?core::marker::Sized
+pub fn hex_conservative::Char::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for hex_conservative::Char where T: ?core::marker::Sized
+pub fn hex_conservative::Char::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for hex_conservative::Char where T: ?core::marker::Sized
+pub fn hex_conservative::Char::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for hex_conservative::Char where T: core::clone::Clone
+pub unsafe fn hex_conservative::Char::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for hex_conservative::Char
+pub fn hex_conservative::Char::from(t: T) -> T
 pub enum hex_conservative::DecodeFixedLengthBytesError
 pub hex_conservative::DecodeFixedLengthBytesError::InvalidChar(hex_conservative::error::InvalidCharError)
 pub hex_conservative::DecodeFixedLengthBytesError::InvalidLength(hex_conservative::error::InvalidLengthError)
@@ -549,14 +620,14 @@ pub fn hex_conservative::BytesToHexIter<I>::fmt(&self, f: &mut core::fmt::Format
 impl<I> core::hash::Hash for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator + core::hash::Hash, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
-pub fn hex_conservative::BytesToHexIter<I>::next_back(&mut self) -> core::option::Option<char>
-pub fn hex_conservative::BytesToHexIter<I>::nth_back(&mut self, n: usize) -> core::option::Option<char>
+pub fn hex_conservative::BytesToHexIter<I>::next_back(&mut self) -> core::option::Option<[hex_conservative::Char; 2]>
+pub fn hex_conservative::BytesToHexIter<I>::nth_back(&mut self, n: usize) -> core::option::Option<[hex_conservative::Char; 2]>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
-pub type hex_conservative::BytesToHexIter<I>::Item = char
-pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
-pub fn hex_conservative::BytesToHexIter<I>::nth(&mut self, n: usize) -> core::option::Option<char>
+pub type hex_conservative::BytesToHexIter<I>::Item = [hex_conservative::Char; 2]
+pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<[hex_conservative::Char; 2]>
+pub fn hex_conservative::BytesToHexIter<I>::nth(&mut self, n: usize) -> core::option::Option<[hex_conservative::Char; 2]>
 pub fn hex_conservative::BytesToHexIter<I>::size_hint(&self) -> (usize, core::option::Option<usize>)
 impl<I> core::iter::traits::marker::FusedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::marker::FusedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 impl<I> core::marker::StructuralPartialEq for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>

--- a/api/no-features.txt
+++ b/api/no-features.txt
@@ -380,6 +380,73 @@ impl<T> core::clone::CloneToUninit for hex_conservative::Case where T: core::clo
 pub unsafe fn hex_conservative::Case::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::Case
 pub fn hex_conservative::Case::from(t: T) -> T
+#[repr(u8)] pub enum hex_conservative::Char
+pub hex_conservative::Char::Eight = 56
+pub hex_conservative::Char::Five = 53
+pub hex_conservative::Char::Four = 52
+pub hex_conservative::Char::LowerA = 97
+pub hex_conservative::Char::LowerB = 98
+pub hex_conservative::Char::LowerC = 99
+pub hex_conservative::Char::LowerD = 100
+pub hex_conservative::Char::LowerE = 101
+pub hex_conservative::Char::LowerF = 102
+pub hex_conservative::Char::Nine = 57
+pub hex_conservative::Char::One = 49
+pub hex_conservative::Char::Seven = 55
+pub hex_conservative::Char::Six = 54
+pub hex_conservative::Char::Three = 51
+pub hex_conservative::Char::Two = 50
+pub hex_conservative::Char::UpperA = 65
+pub hex_conservative::Char::UpperB = 66
+pub hex_conservative::Char::UpperC = 67
+pub hex_conservative::Char::UpperD = 68
+pub hex_conservative::Char::UpperE = 69
+pub hex_conservative::Char::UpperF = 70
+pub hex_conservative::Char::Zero = 48
+impl core::clone::Clone for hex_conservative::Char
+pub fn hex_conservative::Char::clone(&self) -> hex_conservative::Char
+impl core::cmp::Eq for hex_conservative::Char
+impl core::cmp::Ord for hex_conservative::Char
+pub fn hex_conservative::Char::cmp(&self, other: &hex_conservative::Char) -> core::cmp::Ordering
+impl core::cmp::PartialEq for hex_conservative::Char
+pub fn hex_conservative::Char::eq(&self, other: &hex_conservative::Char) -> bool
+impl core::cmp::PartialOrd for hex_conservative::Char
+pub fn hex_conservative::Char::partial_cmp(&self, other: &hex_conservative::Char) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<hex_conservative::Char> for char
+pub fn char::from(c: hex_conservative::Char) -> char
+impl core::convert::From<hex_conservative::Char> for u8
+pub fn u8::from(c: hex_conservative::Char) -> u8
+impl core::fmt::Debug for hex_conservative::Char
+pub fn hex_conservative::Char::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for hex_conservative::Char
+pub fn hex_conservative::Char::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for hex_conservative::Char
+impl core::marker::StructuralPartialEq for hex_conservative::Char
+impl core::marker::Freeze for hex_conservative::Char
+impl core::marker::Send for hex_conservative::Char
+impl core::marker::Sync for hex_conservative::Char
+impl core::marker::Unpin for hex_conservative::Char
+impl core::marker::UnsafeUnpin for hex_conservative::Char
+impl core::panic::unwind_safe::RefUnwindSafe for hex_conservative::Char
+impl core::panic::unwind_safe::UnwindSafe for hex_conservative::Char
+impl<T, U> core::convert::Into<U> for hex_conservative::Char where U: core::convert::From<T>
+pub fn hex_conservative::Char::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for hex_conservative::Char where U: core::convert::Into<T>
+pub type hex_conservative::Char::Error = core::convert::Infallible
+pub fn hex_conservative::Char::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for hex_conservative::Char where U: core::convert::TryFrom<T>
+pub type hex_conservative::Char::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn hex_conservative::Char::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for hex_conservative::Char where T: 'static + ?core::marker::Sized
+pub fn hex_conservative::Char::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for hex_conservative::Char where T: ?core::marker::Sized
+pub fn hex_conservative::Char::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for hex_conservative::Char where T: ?core::marker::Sized
+pub fn hex_conservative::Char::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for hex_conservative::Char where T: core::clone::Clone
+pub unsafe fn hex_conservative::Char::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for hex_conservative::Char
+pub fn hex_conservative::Char::from(t: T) -> T
 pub enum hex_conservative::DecodeFixedLengthBytesError
 pub hex_conservative::DecodeFixedLengthBytesError::InvalidChar(hex_conservative::error::InvalidCharError)
 pub hex_conservative::DecodeFixedLengthBytesError::InvalidLength(hex_conservative::error::InvalidLengthError)
@@ -485,14 +552,14 @@ pub fn hex_conservative::BytesToHexIter<I>::fmt(&self, f: &mut core::fmt::Format
 impl<I> core::hash::Hash for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator + core::hash::Hash, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl<I> core::iter::traits::double_ended::DoubleEndedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::double_ended::DoubleEndedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
-pub fn hex_conservative::BytesToHexIter<I>::next_back(&mut self) -> core::option::Option<char>
-pub fn hex_conservative::BytesToHexIter<I>::nth_back(&mut self, n: usize) -> core::option::Option<char>
+pub fn hex_conservative::BytesToHexIter<I>::next_back(&mut self) -> core::option::Option<[hex_conservative::Char; 2]>
+pub fn hex_conservative::BytesToHexIter<I>::nth_back(&mut self, n: usize) -> core::option::Option<[hex_conservative::Char; 2]>
 impl<I> core::iter::traits::exact_size::ExactSizeIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::exact_size::ExactSizeIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 pub fn hex_conservative::BytesToHexIter<I>::len(&self) -> usize
 impl<I> core::iter::traits::iterator::Iterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
-pub type hex_conservative::BytesToHexIter<I>::Item = char
-pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<char>
-pub fn hex_conservative::BytesToHexIter<I>::nth(&mut self, n: usize) -> core::option::Option<char>
+pub type hex_conservative::BytesToHexIter<I>::Item = [hex_conservative::Char; 2]
+pub fn hex_conservative::BytesToHexIter<I>::next(&mut self) -> core::option::Option<[hex_conservative::Char; 2]>
+pub fn hex_conservative::BytesToHexIter<I>::nth(&mut self, n: usize) -> core::option::Option<[hex_conservative::Char; 2]>
 pub fn hex_conservative::BytesToHexIter<I>::size_hint(&self) -> (usize, core::option::Option<usize>)
 impl<I> core::iter::traits::marker::FusedIterator for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::marker::FusedIterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>
 impl<I> core::marker::StructuralPartialEq for hex_conservative::BytesToHexIter<I> where I: core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: core::borrow::Borrow<u8>

--- a/benches/hex/iter.rs
+++ b/benches/hex/iter.rs
@@ -4,14 +4,16 @@ use std::hint::black_box;
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use hex_conservative::{BytesToHexIter, Case};
+use hex_conservative::{BytesToHexIter, Case, Char};
 
 fn nth_positions(size: usize) -> [usize; 5] {
-    let total = size * 2;
-    [size / 8, size / 2, size, size + size / 2, total - 1]
+    [size / 8, size / 4, size / 2, size * 3 / 4, size - 1]
 }
 
-fn slow_nth(iter: &mut BytesToHexIter<core::slice::Iter<'_, u8>>, n: usize) -> Option<char> {
+fn slow_nth(
+    iter: &mut BytesToHexIter<core::slice::Iter<'_, u8>>,
+    n: usize,
+) -> Option<[Char; 2]> {
     for _ in 0..n {
         iter.next()?;
     }
@@ -21,7 +23,7 @@ fn slow_nth(iter: &mut BytesToHexIter<core::slice::Iter<'_, u8>>, n: usize) -> O
 fn slow_nth_back(
     iter: &mut BytesToHexIter<core::slice::Iter<'_, u8>>,
     n: usize,
-) -> Option<char> {
+) -> Option<[Char; 2]> {
     for _ in 0..n {
         iter.next_back()?;
     }
@@ -41,7 +43,8 @@ fn bench_bytes_to_hex_nth(c: &mut Criterion) {
                 let mut sum = 0u32;
                 for &n in &positions {
                     let mut iter = BytesToHexIter::new(black_box(bytes.as_slice()).iter(), Case::Lower);
-                    sum += u32::from(iter.nth(black_box(n)).unwrap());
+                    let [hi, lo] = iter.nth(black_box(n)).unwrap();
+                    sum += u32::from(u8::from(hi)) + u32::from(u8::from(lo));
                 }
                 black_box(sum)
             });
@@ -52,7 +55,8 @@ fn bench_bytes_to_hex_nth(c: &mut Criterion) {
                 let mut sum = 0u32;
                 for &n in &positions {
                     let mut iter = BytesToHexIter::new(black_box(bytes.as_slice()).iter(), Case::Lower);
-                    sum += u32::from(slow_nth(&mut iter, black_box(n)).unwrap());
+                    let [hi, lo] = slow_nth(&mut iter, black_box(n)).unwrap();
+                    sum += u32::from(u8::from(hi)) + u32::from(u8::from(lo));
                 }
                 black_box(sum)
             });
@@ -75,7 +79,8 @@ fn bench_bytes_to_hex_nth_back(c: &mut Criterion) {
                 let mut sum = 0u32;
                 for &n in &positions {
                     let mut iter = BytesToHexIter::new(black_box(bytes.as_slice()).iter(), Case::Lower);
-                    sum += u32::from(iter.nth_back(black_box(n)).unwrap());
+                    let [hi, lo] = iter.nth_back(black_box(n)).unwrap();
+                    sum += u32::from(u8::from(hi)) + u32::from(u8::from(lo));
                 }
                 black_box(sum)
             });
@@ -86,7 +91,8 @@ fn bench_bytes_to_hex_nth_back(c: &mut Criterion) {
                 let mut sum = 0u32;
                 for &n in &positions {
                     let mut iter = BytesToHexIter::new(black_box(bytes.as_slice()).iter(), Case::Lower);
-                    sum += u32::from(slow_nth_back(&mut iter, black_box(n)).unwrap());
+                    let [hi, lo] = slow_nth_back(&mut iter, black_box(n)).unwrap();
+                    sum += u32::from(u8::from(hi)) + u32::from(u8::from(lo));
                 }
                 black_box(sum)
             });

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -12,7 +12,7 @@ use std::io;
 #[cfg(feature = "alloc")]
 use crate::alloc::vec::Vec;
 use crate::error::{InvalidCharError, OddLengthStringError};
-use crate::{Case, Table};
+use crate::{Case, Char, Table};
 
 /// Iterator over bytes decoded from a hex string slice.
 ///
@@ -287,7 +287,28 @@ fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, (u8, bool)> {
     Ok(ret as u8)
 }
 
-/// Iterator over bytes which encodes the bytes and yields hex characters.
+/// Iterator over bytes which encodes the bytes and yields `[Char; 2]` pairs of hex characters.
+///
+/// Each call to [`Iterator::next`] consumes one byte and returns the two hex digits that encode
+/// it as `[high_nibble, low_nibble]`.
+///
+/// If you want to yield a stream of [`Char`] only, call [`flatten`].
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "alloc")]
+/// # {
+/// use hex_conservative::{BytesToHexIter, Case};
+///
+/// let bytes = [0xde, 0xad, 0xbe, 0xef].into_iter();
+/// let hex_string: String =
+///     BytesToHexIter::new(bytes, Case::Lower).flatten().map(char::from).collect();
+/// assert_eq!(hex_string, "deadbeef");
+/// # }
+///```
+///
+/// [`flatten`]: Iterator::flatten
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BytesToHexIter<I>
 where
@@ -296,8 +317,6 @@ where
 {
     /// The iterator whose next byte will be encoded to yield hex characters.
     iter: I,
-    /// The low character of the pair (high, low) of hex characters encoded per byte.
-    low: Option<char>,
     /// The byte-to-hex conversion table.
     table: &'static Table,
 }
@@ -307,11 +326,9 @@ where
     I: Iterator,
     I::Item: Borrow<u8>,
 {
-    /// Constructs a `BytesToHexIter` that will yield hex characters in the given case from a byte
-    /// iterator.
-    pub fn new(iter: I, case: Case) -> BytesToHexIter<I> {
-        Self { iter, low: None, table: case.table() }
-    }
+    /// Constructs a `BytesToHexIter` that will yield hex character pairs in the given case from a
+    /// byte iterator.
+    pub fn new(iter: I, case: Case) -> BytesToHexIter<I> { Self { iter, table: case.table() } }
 }
 
 impl<I> Iterator for BytesToHexIter<I>
@@ -319,46 +336,19 @@ where
     I: Iterator,
     I::Item: Borrow<u8>,
 {
-    type Item = char;
+    type Item = [Char; 2];
 
     #[inline]
-    fn next(&mut self) -> Option<char> {
-        match self.low {
-            Some(c) => {
-                self.low = None;
-                Some(c)
-            }
-            None => self.iter.next().map(|b| {
-                let [high, low] = self.table.byte_to_chars(*b.borrow());
-                self.low = Some(low);
-                high
-            }),
-        }
+    fn next(&mut self) -> Option<[Char; 2]> {
+        self.iter.next().map(|b| self.table.byte_to_hex_chars(*b.borrow()))
     }
 
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let (min, max) = self.iter.size_hint();
-        match self.low {
-            Some(_) => (min * 2 + 1, max.map(|max| max * 2 + 1)),
-            None => (min * 2, max.map(|max| max * 2)),
-        }
-    }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 
     #[inline]
-    fn nth(&mut self, n: usize) -> Option<char> {
-        let had_low = self.low.is_some();
-        if let Some(c) = self.low.take() {
-            if n == 0 {
-                return Some(c);
-            }
-        }
-
-        let n = n - usize::from(had_low);
-        let [high, low] = self.table.byte_to_chars(*self.iter.nth(n / 2)?.borrow());
-        self.low = if n % 2 == 0 { Some(low) } else { None };
-
-        Some(if n % 2 == 0 { high } else { low })
+    fn nth(&mut self, n: usize) -> Option<[Char; 2]> {
+        self.iter.nth(n).map(|b| self.table.byte_to_hex_chars(*b.borrow()))
     }
 }
 
@@ -368,34 +358,13 @@ where
     I::Item: Borrow<u8>,
 {
     #[inline]
-    fn next_back(&mut self) -> Option<char> {
-        match self.low {
-            Some(c) => {
-                self.low = None;
-                Some(c)
-            }
-            None => self.iter.next_back().map(|b| {
-                let [high, low] = self.table.byte_to_chars(*b.borrow());
-                self.low = Some(low);
-                high
-            }),
-        }
+    fn next_back(&mut self) -> Option<[Char; 2]> {
+        self.iter.next_back().map(|b| self.table.byte_to_hex_chars(*b.borrow()))
     }
 
     #[inline]
-    fn nth_back(&mut self, n: usize) -> Option<char> {
-        let had_low = self.low.is_some();
-        if let Some(c) = self.low.take() {
-            if n == 0 {
-                return Some(c);
-            }
-        }
-
-        let n = n - usize::from(had_low);
-        let [high, low] = self.table.byte_to_chars(*self.iter.nth_back(n / 2)?.borrow());
-        self.low = if n % 2 == 0 { Some(low) } else { None };
-
-        Some(if n % 2 == 0 { high } else { low })
+    fn nth_back(&mut self, n: usize) -> Option<[Char; 2]> {
+        self.iter.nth_back(n).map(|b| self.table.byte_to_hex_chars(*b.borrow()))
     }
 }
 
@@ -405,7 +374,7 @@ where
     I::Item: Borrow<u8>,
 {
     #[inline]
-    fn len(&self) -> usize { self.iter.len() * 2 + usize::from(self.low.is_some()) }
+    fn len(&self) -> usize { self.iter.len() }
 }
 
 impl<I> FusedIterator for BytesToHexIter<I>
@@ -646,39 +615,65 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn encode_iter() {
         let bytes = [0xde, 0xad, 0xbe, 0xef];
         let lower_want = "deadbeef";
         let upper_want = "DEADBEEF";
 
-        for (i, c) in BytesToHexIter::new(bytes.iter(), Case::Lower).enumerate() {
-            assert_eq!(c, lower_want.chars().nth(i).unwrap());
-        }
-        for (i, c) in BytesToHexIter::new(bytes.iter(), Case::Upper).enumerate() {
-            assert_eq!(c, upper_want.chars().nth(i).unwrap());
-        }
+        let lower_got: String =
+            BytesToHexIter::new(bytes.iter(), Case::Lower).flatten().map(char::from).collect();
+        assert_eq!(lower_got, lower_want);
+        let upper_got: String =
+            BytesToHexIter::new(bytes.iter(), Case::Upper).flatten().map(char::from).collect();
+        assert_eq!(upper_got, upper_want);
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn encode_iter_backwards() {
         let bytes = [0xde, 0xad, 0xbe, 0xef];
+        // .rev().flatten() yields pairs in reverse byte order but each pair remains [high, low].
         let lower_want = "efbeadde";
         let upper_want = "EFBEADDE";
 
-        for (i, c) in BytesToHexIter::new(bytes.iter(), Case::Lower).rev().enumerate() {
-            assert_eq!(c, lower_want.chars().nth(i).unwrap());
-        }
-        for (i, c) in BytesToHexIter::new(bytes.iter(), Case::Upper).rev().enumerate() {
-            assert_eq!(c, upper_want.chars().nth(i).unwrap());
-        }
+        let lower_got: String = BytesToHexIter::new(bytes.iter(), Case::Lower)
+            .rev()
+            .flatten()
+            .map(char::from)
+            .collect();
+        assert_eq!(lower_got, lower_want);
+        let upper_got: String = BytesToHexIter::new(bytes.iter(), Case::Upper)
+            .rev()
+            .flatten()
+            .map(char::from)
+            .collect();
+        assert_eq!(upper_got, upper_want);
+
+        // .flatten().rev() yields pairs in reverse byte order and each pair becomes [low, high].
+        let lower_want = "feebdaed";
+        let upper_want = "FEEBDAED";
+
+        let lower_got: String = BytesToHexIter::new(bytes.iter(), Case::Lower)
+            .flatten()
+            .rev()
+            .map(char::from)
+            .collect();
+        assert_eq!(lower_got, lower_want);
+        let upper_got: String = BytesToHexIter::new(bytes.iter(), Case::Upper)
+            .flatten()
+            .rev()
+            .map(char::from)
+            .collect();
+        assert_eq!(upper_got, upper_want);
     }
 
     #[test]
     fn encode_iter_nth() {
         let bytes = [0xde, 0xad, 0xbe, 0xef];
 
-        for n in 0..=bytes.len() * 2 + 1 {
+        for n in 0..=bytes.len() + 1 {
             let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
             let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
 
@@ -692,7 +687,7 @@ mod tests {
     fn encode_iter_nth_after_next_back() {
         let bytes = [0xde, 0xad, 0xbe, 0xef];
 
-        for n in 0..=bytes.len() * 2 {
+        for n in 0..=bytes.len() {
             let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
             let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
 
@@ -707,7 +702,7 @@ mod tests {
     fn encode_iter_nth_after_next() {
         let bytes = [0xde, 0xad, 0xbe, 0xef];
 
-        for n in 0..=bytes.len() * 2 {
+        for n in 0..=bytes.len() {
             let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
             let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
 
@@ -722,7 +717,7 @@ mod tests {
     fn encode_iter_nth_back() {
         let bytes = [0xde, 0xad, 0xbe, 0xef];
 
-        for n in 0..=bytes.len() * 2 + 1 {
+        for n in 0..=bytes.len() + 1 {
             let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
             let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
 
@@ -736,7 +731,7 @@ mod tests {
     fn encode_iter_nth_back_after_next() {
         let bytes = [0xde, 0xad, 0xbe, 0xef];
 
-        for n in 0..=bytes.len() * 2 {
+        for n in 0..=bytes.len() {
             let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
             let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
 
@@ -751,7 +746,7 @@ mod tests {
     fn encode_iter_nth_back_after_next_back() {
         let bytes = [0xde, 0xad, 0xbe, 0xef];
 
-        for n in 0..=bytes.len() * 2 {
+        for n in 0..=bytes.len() {
             let mut got = BytesToHexIter::new(bytes.iter(), Case::Lower);
             let mut want = BytesToHexIter::new(bytes.iter(), Case::Lower);
 
@@ -768,10 +763,12 @@ mod tests {
         let lower_want = "deadbeefcafebabe";
         let upper_want = "DEADBEEFCAFEBABE";
         let lower_bytes_iter = HexToBytesIter::new(lower_want).unwrap().map(|res| res.unwrap());
-        let lower_got = BytesToHexIter::new(lower_bytes_iter, Case::Lower).collect::<String>();
+        let lower_got: String =
+            BytesToHexIter::new(lower_bytes_iter, Case::Lower).flatten().map(char::from).collect();
         assert_eq!(lower_got, lower_want);
         let upper_bytes_iter = HexToBytesIter::new(upper_want).unwrap().map(|res| res.unwrap());
-        let upper_got = BytesToHexIter::new(upper_bytes_iter, Case::Upper).collect::<String>();
+        let upper_got: String =
+            BytesToHexIter::new(upper_bytes_iter, Case::Upper).flatten().map(char::from).collect();
         assert_eq!(upper_got, upper_want);
     }
 
@@ -782,13 +779,19 @@ mod tests {
         let upper_want = "DEADBEEFCAFEBABE";
         let lower_bytes_iter =
             HexToBytesIter::new(lower_want).unwrap().rev().map(|res| res.unwrap());
-        let lower_got =
-            BytesToHexIter::new(lower_bytes_iter, Case::Lower).rev().collect::<String>();
+        let lower_got: String = BytesToHexIter::new(lower_bytes_iter, Case::Lower)
+            .rev()
+            .flatten()
+            .map(char::from)
+            .collect();
         assert_eq!(lower_got, lower_want);
         let upper_bytes_iter =
             HexToBytesIter::new(upper_want).unwrap().rev().map(|res| res.unwrap());
-        let upper_got =
-            BytesToHexIter::new(upper_bytes_iter, Case::Upper).rev().collect::<String>();
+        let upper_got: String = BytesToHexIter::new(upper_bytes_iter, Case::Upper)
+            .rev()
+            .flatten()
+            .map(char::from)
+            .collect();
         assert_eq!(upper_got, upper_want);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,23 +220,94 @@ impl Case {
     }
 }
 
+/// A valid hex character: one of `[0-9a-fA-F]`.
+//
+// The `repr(u8)` guarantees that representation matches the ASCII byte value of the character,
+// making transmute between `Char` and `u8` safe whenever the byte is a valid hex digit.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u8)]
+pub enum Char {
+    /// `'0'`
+    Zero = b'0',
+    /// `'1'`
+    One = b'1',
+    /// `'2'`
+    Two = b'2',
+    /// `'3'`
+    Three = b'3',
+    /// `'4'`
+    Four = b'4',
+    /// `'5'`
+    Five = b'5',
+    /// `'6'`
+    Six = b'6',
+    /// `'7'`
+    Seven = b'7',
+    /// `'8'`
+    Eight = b'8',
+    /// `'9'`
+    Nine = b'9',
+    /// `'a'`
+    LowerA = b'a',
+    /// `'b'`
+    LowerB = b'b',
+    /// `'c'`
+    LowerC = b'c',
+    /// `'d'`
+    LowerD = b'd',
+    /// `'e'`
+    LowerE = b'e',
+    /// `'f'`
+    LowerF = b'f',
+    /// `'A'`
+    UpperA = b'A',
+    /// `'B'`
+    UpperB = b'B',
+    /// `'C'`
+    UpperC = b'C',
+    /// `'D'`
+    UpperD = b'D',
+    /// `'E'`
+    UpperE = b'E',
+    /// `'F'`
+    UpperF = b'F',
+}
+
+impl From<Char> for char {
+    #[inline]
+    fn from(c: Char) -> char { char::from(c as u8) }
+}
+
+impl From<Char> for u8 {
+    #[inline]
+    fn from(c: Char) -> u8 { c as u8 }
+}
+
 /// Correctness boundary for `Table`.
 mod table {
+    use super::Char;
+
     /// Table of hex chars.
     //
     // Correctness invariant: each byte in the table must be ASCII.
     #[allow(clippy::derived_hash_with_manual_eq)] // The Eq impl distinguishes the two possible values of Table
     #[derive(Debug, Hash)]
-    pub(crate) struct Table([u8; 16]);
+    pub(crate) struct Table([Char; 16]);
 
     impl Table {
+        #[rustfmt::skip] // rustfmt wants to make these one per line.
         pub(crate) const LOWER: Self = Table([
-            b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b', b'c', b'd',
-            b'e', b'f',
+            Char::Zero, Char::One, Char::Two, Char::Three,
+            Char::Four, Char::Five, Char::Six, Char::Seven,
+            Char::Eight, Char::Nine, Char::LowerA, Char::LowerB,
+            Char::LowerC, Char::LowerD, Char::LowerE, Char::LowerF,
         ]);
+        #[rustfmt::skip] // rustfmt wants to make these one per line.
         pub(crate) const UPPER: Self = Table([
-            b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'A', b'B', b'C', b'D',
-            b'E', b'F',
+            Char::Zero, Char::One, Char::Two, Char::Three,
+            Char::Four, Char::Five, Char::Six, Char::Seven,
+            Char::Eight, Char::Nine, Char::UpperA, Char::UpperB,
+            Char::UpperC, Char::UpperD, Char::UpperE, Char::UpperF,
         ]);
 
         /// Encodes single byte as two ASCII chars using the given table.
@@ -244,9 +315,7 @@ mod table {
         /// The function guarantees only returning values from the provided table.
         #[inline]
         pub(crate) fn byte_to_chars(&self, byte: u8) -> [char; 2] {
-            let left = self.0[usize::from(byte >> 4)];
-            let right = self.0[usize::from(byte & 0x0F)];
-            [char::from(left), char::from(right)]
+            self.byte_to_hex_chars(byte).map(char::from)
         }
 
         /// Writes the single byte as two ASCII chars in the provided buffer, and returns a `&str`
@@ -255,16 +324,26 @@ mod table {
         /// The function guarantees only returning values from the provided table.
         #[inline]
         pub(crate) fn byte_to_str<'a>(&self, dest: &'a mut [u8; 2], byte: u8) -> &'a str {
-            dest[0] = self.0[usize::from(byte >> 4)];
-            dest[1] = self.0[usize::from(byte & 0x0F)];
+            dest[0] = self.0[usize::from(byte >> 4)].into();
+            dest[1] = self.0[usize::from(byte & 0x0F)].into();
             // SAFETY: Table inner array contains only valid ascii
             let hex_str = unsafe { core::str::from_utf8_unchecked(dest) };
             hex_str
         }
+
+        /// Encodes a single byte as two [`Char`] values using the given table.
+        ///
+        /// The function guarantees only returning values from the provided table.
+        #[inline]
+        pub(crate) fn byte_to_hex_chars(&self, byte: u8) -> [Char; 2] {
+            let left = self.0[usize::from(byte >> 4)];
+            let right = self.0[usize::from(byte & 0x0F)];
+            [left, right]
+        }
     }
 
     impl PartialEq for Table {
-        // Table can only be Table::LOWER or Table::UPPER. These differ in any of the bytes from
+        // Table can only be Table::LOWER or Table::UPPER. These differ in any of the Chars from
         // indices 10-15.
         fn eq(&self, other: &Self) -> bool { self.0[10] == other.0[10] }
     }


### PR DESCRIPTION
Currently, BytesToHexIter takes in u8 and returns char. By introducting an enum Char type, we can use that in place of char to improve type safety. Further, by returning pairs of Chars, we can eliminate bugs associated with the internal buffer and allow users to trivially control character/nibble order during encoding.

- Patch 1 introduces the Char enum and replaces u8 in Table with it
- Patch 2 rewrites BytesToHexIter to return [Char; 2], including updating the benchmarks to suit.
- Patch 3 updates the api files.

Closes #234