### PR TITLE
Update crate docs MSRV policy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,11 +53,11 @@
 //!   do nothing once the native detection is in Rust and our MSRV is at least that version. We may
 //!   also remove the feature gate in 2.0 with semver trick once that happens.
 //!
-//! ## MSRV policy
+//! ## Minimum Supported Rust Version (MSRV)
 //!
-//! The MSRV of the crate is currently 1.63.0 and we don't intend to bump it until the newer Rust
-//! version is at least two years old and also included in Debian stable (1.63 is in Debian 12 at
-//! the moment).
+//! The current MSRV is Rust `1.74.0`. Policy is to never use an MSRV that is less than two years
+//! old and also that ships in Debian stable. We may bump our MSRV in a minor version, but we have
+//! no plans to.
 //!
 //! Note though that the dependencies may have looser policy. This is not considered breaking/wrong
 //! - you would just need to pin them in `Cargo.lock` (not `.toml`).


### PR DESCRIPTION
In #216 we bumped the MSRV including new docs in the readme. I forgot to update the crate level docs.

Loosely copy the docs from the readme and update the crate level docs.

While reviewing HMTL I did patch 2, open question in the commit log.