### PR TITLE
Copy v1.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 - Add `hex!` macro for const hex literal parsing.
 - Bump the MSRV
 
+# 1.0.1 - 2025-12-02
+
+- Remove `doc_auto_cfg`
+
+# 1.0.0 - 2025-07-11
+
+- Removed niche reexports from root
+- Various documentation improvements
+- A few test improvements
+
+# 1.0.0 release candidate 2 -- 2025-06-27
+
+- Removed iterator API that got published by accident
+
+# 1.0.0 release candidate 1 -- 2025-05-16
+
+- Exports `decode_to_array`, `decode_to_vec`, and all error types.
+
+The goal of this release is to enable library authors to use hex-conservative,
+exposing error types from this library in their own APIs, and not need to worry
+that they will face API breakage because of this.
+
+Future minor releases will add encoding support and a more expansive set of traits.
+
 # 0.3.0 - 2024-09-18
 
 - Re-implement `HexWriter` [#113](https://github.com/rust-bitcoin/hex-conservative/pull/113)


### PR DESCRIPTION
Copy the release notes from the `1.x` branch. This should have been done as part of #206 "Prepare master to be v1.1"