### PR TITLE
Revert "Make iter module public"

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -29,7 +29,8 @@ impl<'a> HexToBytesIter<HexDigitsIter<'a>> {
     ///
     /// If the input string is of odd length.
     #[inline]
-    pub fn new(s: &'a str) -> Result<Self, OddLengthStringError> {
+    #[allow(dead_code)] // Remove this when making HexToBytesIter public.
+    pub(crate) fn new(s: &'a str) -> Result<Self, OddLengthStringError> {
         if s.len() % 2 != 0 {
             Err(OddLengthStringError { len: s.len() })
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod _export {
 }
 
 pub mod error;
-pub mod iter;
+mod iter;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;


### PR DESCRIPTION
This reverts commit 508962bd30b70c5cce65971b1e69d4de2c4bba06.

We are now releasing `v1.1.0` from master branch so this branch will only be for security patches to `v1.0`. As such we don't want any other changes on the branch.

Over on master we kept the `iter` module private and re-exported the iterator types from the crate root.