### PR TITLE
Use `Char` table lookup to improve decode performance

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -14,4 +14,9 @@
  name = "iter"
  path = "hex/iter.rs"
  harness = false
+
+ [[bench]]
+ name = "decode"
+ path = "hex/decode.rs"
+ harness = false
  

--- a/benches/hex/decode.rs
+++ b/benches/hex/decode.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use hex_conservative::{decode_to_array, decode_to_vec};
+
+fn bench_decode_to_array(c: &mut Criterion) {
+    let mut g = c.benchmark_group("decode_to_array");
+    g.warm_up_time(Duration::from_secs(1)).measurement_time(Duration::from_secs(3));
+
+    // 4 bytes / 8 hex chars
+    let hex_8 = "deadbeef";
+    g.bench_function(BenchmarkId::new("bytes", 4), |b| {
+        b.iter(|| decode_to_array::<4>(black_box(hex_8)).unwrap());
+    });
+
+    // 32 bytes / 64 hex chars
+    let hex_64 = "deadbeef".repeat(8);
+    g.bench_function(BenchmarkId::new("bytes", 32), |b| {
+        b.iter(|| decode_to_array::<32>(black_box(hex_64.as_str())).unwrap());
+    });
+
+    // 256 bytes / 512 hex chars
+    let hex_512 = "ab".repeat(256);
+    g.bench_function(BenchmarkId::new("bytes", 256), |b| {
+        b.iter(|| decode_to_array::<256>(black_box(hex_512.as_str())).unwrap());
+    });
+
+    g.finish();
+}
+
+fn bench_decode_to_vec(c: &mut Criterion) {
+    let mut g = c.benchmark_group("decode_to_vec");
+    g.warm_up_time(Duration::from_secs(1)).measurement_time(Duration::from_secs(3));
+
+    // 4 bytes / 8 hex chars
+    let hex_8 = "deadbeef";
+    g.bench_function(BenchmarkId::new("bytes", 4), |b| {
+        b.iter(|| decode_to_vec(black_box(hex_8)).unwrap());
+    });
+
+    // 32 bytes / 64 hex chars
+    let hex_64 = "deadbeef".repeat(8);
+    g.bench_function(BenchmarkId::new("bytes", 32), |b| {
+        b.iter(|| decode_to_vec(black_box(hex_64.as_str())).unwrap());
+    });
+
+    // 256 bytes / 512 hex chars
+    let hex_512 = "ab".repeat(256);
+    g.bench_function(BenchmarkId::new("bytes", 256), |b| {
+        b.iter(|| decode_to_vec(black_box(hex_512.as_str())).unwrap());
+    });
+
+    g.finish();
+}
+
+criterion_group!(benches, bench_decode_to_array, bench_decode_to_vec);
+criterion_main!(benches);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -310,11 +310,9 @@ impl core::iter::FusedIterator for HexDigitsIter<'_> {}
 ///
 /// Returns the valid byte or the invalid input byte and a bool indicating error for `hi` or `lo`.
 fn hex_chars_to_byte(hi: u8, lo: u8) -> Result<u8, (u8, bool)> {
-    let hih = (hi as char).to_digit(16).ok_or((hi, true))?;
-    let loh = (lo as char).to_digit(16).ok_or((lo, false))?;
-
-    let ret = (hih << 4) + loh;
-    Ok(ret as u8)
+    let hih = Char::decode_nibble(hi).ok_or((hi, true))?;
+    let loh = Char::decode_nibble(lo).ok_or((lo, false))?;
+    Ok((hih << 4) | loh)
 }
 
 /// Iterator over bytes which encodes the bytes and yields `[Char; 2]` pairs of hex characters.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,6 +275,36 @@ pub enum Char {
 }
 
 impl Char {
+    /// Returns the nibble value (0–15) of this hex character.
+    #[inline]
+    pub(crate) fn decode_nibble(b: u8) -> Option<u8> {
+        // Each valid hex byte maps to its nibble value; 0xFF marks invalid entries.
+        // Char variant discriminants equal their ASCII byte values, so they index directly.
+        #[rustfmt::skip]
+        static TABLE: [u8; 256] = {
+            let mut t = [0xFF_u8; 256];
+            // Each Char variant is a u8. So all `as usize` casts are safe.
+            t[Char::Zero  as usize] = 0;  t[Char::One   as usize] = 1;
+            t[Char::Two   as usize] = 2;  t[Char::Three as usize] = 3;
+            t[Char::Four  as usize] = 4;  t[Char::Five  as usize] = 5;
+            t[Char::Six   as usize] = 6;  t[Char::Seven as usize] = 7;
+            t[Char::Eight as usize] = 8;  t[Char::Nine  as usize] = 9;
+            t[Char::LowerA as usize] = 10; t[Char::UpperA as usize] = 10;
+            t[Char::LowerB as usize] = 11; t[Char::UpperB as usize] = 11;
+            t[Char::LowerC as usize] = 12; t[Char::UpperC as usize] = 12;
+            t[Char::LowerD as usize] = 13; t[Char::UpperD as usize] = 13;
+            t[Char::LowerE as usize] = 14; t[Char::UpperE as usize] = 14;
+            t[Char::LowerF as usize] = 15; t[Char::UpperF as usize] = 15;
+            t
+        };
+        let n = TABLE[usize::from(b)];
+        if n == 0xFF {
+            None
+        } else {
+            Some(n)
+        }
+    }
+
     /// Casts a slice of `Char`s to `&str`.
     ///
     /// This conversion is zero-cost.


### PR DESCRIPTION
The decode performance is currently hampered by the hex_chars_to_byte function which converts u8 pairs to chars, then to u32s before combining them to a single u8 byte. Using the Char type, we can make a lookup table on the stack and dramatically improve decode performance.

- Patch 1 introduces a benchmark for decode_to_array and decode_to_vec.
- Patch 2 adds decode_nibble on Char to decode a u8 hex char to a nibble value and uses this for decoding in hex_chars_to_byte.