### PR TITLE
Release tracking PR: `hex-conservative 1.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0 - 2026-05-22
+
+- Add `fmt_hex_exact_lower` and `fmt_hex_exact_upper` macros [#247](https://github.com/rust-bitcoin/hex-conservative/pull/247)
+
 # 1.1.0 - 2026-05-04
 
 `v1.0` of this crate only has the decoding side (and the decoding iterator is private).

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -10,7 +10,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "hex-conservative"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "arrayvec",
  "if_rust_version",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -10,7 +10,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "hex-conservative"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "arrayvec",
  "if_rust_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hex-conservative"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>", "Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/hex-conservative"


### PR DESCRIPTION
Another quick release to add a couple of macros for the sake of ergonomics.
    
In preparation bump the version number, add a changelog entry, and update the lock files.
