### PR TITLE
Mention HexSliceToBytesIter in HexToBytesIter docs

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -82,6 +82,9 @@ impl io::Read for HexSliceToBytesIter<'_> {
 }
 
 /// Iterator yielding bytes decoded from an iterator of pairs of hex digits.
+///
+/// This type is intentionally low-level. It operates on an iterator of character pairs, each
+/// represented as a `[u8; 2]`. If you already have a `&str`, use [`HexSliceToBytesIter`] instead.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct HexToBytesIter<I>
 where


### PR DESCRIPTION
The HexToBytesIter docs are currently quite sparse, which can be confusing since the type now has less functionality than in 0.3.0. To help users of the old HexToBytesIter::new function find the new equivalent in HexSliceToBytesIter, the docs on the HexToBytesIter type should be expanded.

Add mention of HexSliceToBytesIter to HexToBytesIter for users with &str.