### PR TITLE
Add pos field to InvalidCharInt

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -75,16 +75,19 @@ impl From<OddLengthStringError> for HexToBytesError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidCharError {
     pub(crate) invalid: u8,
+    pub(crate) pos: usize,
 }
 
 impl InvalidCharError {
     /// Returns the invalid character byte.
     pub fn invalid_char(&self) -> u8 { self.invalid }
+    /// Returns the position of the invalid character byte.
+    pub fn pos(&self) -> usize { self.pos }
 }
 
 impl fmt::Display for InvalidCharError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "invalid hex char {}", self.invalid)
+        write!(f, "invalid hex char {} at pos {}", self.invalid, self.pos)
     }
 }
 


### PR DESCRIPTION
In commit d7b4be55 in 0.3.x and 1.x we added the `pos`. It is used then in the `HexToBytesIter`.

We would like to massage the `DecodeFixedLengthBytesError` from the 1.x release so it can be type aliased as `HexToArrayError` in `0.2` and `0.3`. Currently however the `HexToArrayError`s differ in these two releases but only by the `pos` field and function of the `InvalidCharError`.

In preparation for the modifications on `master`, and to make review more sane, lets make the `InvalidCharError`s the same on the `0.2` and `0.3` branches.

Note we do not patch the `HexToBytesIter` because that would be a breaking change - cest la vie.