### PR TITLE
Remove core2 depedency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ alloc = []
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
-core2 = { version = "0.3.2", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="std alloc core2 serde"
+FEATURES="std alloc serde"
 MSRV="1\.56\.0"
 
 cargo --version

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -21,10 +21,10 @@ if cargo --version | grep ${MSRV}; then
     cargo update -p serde --precise 1.0.156
     cargo update -p quote --precise 1.0.0
     cargo update -p proc-macro2 --precise 1.0.63
-    # memchr 2.6.0 uses edition 2021
-    cargo update -p memchr --precise 2.5.0
-    cargo update -p ryu --precise 1.0.0
-    cargo update -p unicode-ident --precise 1.0.0
+    # unicode-ident 1.0.23 requires rustc 1.71
+    cargo update -p unicode-ident --precise 1.0.22
+    # ryu 1.0.21 requires rustc 1.68
+    cargo update -p ryu --precise 1.0.20
 fi
 
 # Make all cargo invocations verbose

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,3 +19,6 @@ path = "fuzz_targets/hex.rs"
 [[bin]]
 name = "encode"
 path = "fuzz_targets/encode.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)'] }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -8,9 +8,6 @@ use core::str;
 #[cfg(feature = "std")]
 use std::io;
 
-#[cfg(all(feature = "core2", not(feature = "std")))]
-use core2::io;
-
 use crate::error::{InvalidCharError, OddLengthStringError};
 
 /// Convenience alias for `HexToBytesIter<HexDigitsIter<'a>>`.
@@ -87,7 +84,7 @@ impl<T: Iterator<Item = [u8; 2]> + ExactSizeIterator> ExactSizeIterator for HexT
 
 impl<T: Iterator<Item = [u8; 2]> + FusedIterator> FusedIterator for HexToBytesIter<T> {}
 
-#[cfg(any(feature = "std", feature = "core2"))]
+#[cfg(feature = "std")]
 impl<T: Iterator<Item = [u8; 2]> + FusedIterator> io::Read for HexToBytesIter<T> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,14 +117,8 @@ mod table {
     pub(crate) struct Table([u8; 16]);
 
     impl Table {
-        pub(crate) const LOWER: Self = Table([
-            b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b', b'c', b'd',
-            b'e', b'f',
-        ]);
-        pub(crate) const UPPER: Self = Table([
-            b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'A', b'B', b'C', b'D',
-            b'E', b'F',
-        ]);
+        pub(crate) const LOWER: Self = Table(*b"0123456789abcdef");
+        pub(crate) const UPPER: Self = Table(*b"0123456789ABCDEF");
 
         /// Encodes single byte as two ASCII chars using the given table.
         ///


### PR DESCRIPTION
The `core2` crate was unilaterally yanked borking our build.

Remove the dep. This will require a semver violation to release a set of breaking changes in a point release for the `0.2.x` series.

... And add a bunch of lint patches.