### PR TITLE
Patch sub-errors to make them backwards compatible

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -278,6 +278,7 @@ impl<T> core::convert::From<T> for hex_conservative::error::DecodeVariableLength
 pub fn hex_conservative::error::DecodeVariableLengthBytesError::from(t: T) -> T
 pub struct hex_conservative::error::InvalidCharError
 impl hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
 pub fn hex_conservative::error::InvalidCharError::offset(self, by_bytes: usize) -> Self
 pub fn hex_conservative::error::InvalidCharError::pos(&self) -> usize
 impl core::clone::Clone for hex_conservative::error::InvalidCharError
@@ -329,7 +330,9 @@ impl<T> core::clone::CloneToUninit for hex_conservative::error::InvalidCharError
 pub unsafe fn hex_conservative::error::InvalidCharError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::error::InvalidCharError
 pub fn hex_conservative::error::InvalidCharError::from(t: T) -> T
-pub struct hex_conservative::error::InvalidLengthError
+#[non_exhaustive] pub struct hex_conservative::error::InvalidLengthError
+pub hex_conservative::error::InvalidLengthError::expected: usize
+pub hex_conservative::error::InvalidLengthError::invalid: usize
 impl hex_conservative::error::InvalidLengthError
 pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
 pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
@@ -849,6 +852,7 @@ impl<T> core::convert::From<T> for hex_conservative::HexToBytesIter<I>
 pub fn hex_conservative::HexToBytesIter<I>::from(t: T) -> T
 pub struct hex_conservative::InvalidCharError
 impl hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
 pub fn hex_conservative::error::InvalidCharError::offset(self, by_bytes: usize) -> Self
 pub fn hex_conservative::error::InvalidCharError::pos(&self) -> usize
 impl core::clone::Clone for hex_conservative::error::InvalidCharError
@@ -900,7 +904,9 @@ impl<T> core::clone::CloneToUninit for hex_conservative::error::InvalidCharError
 pub unsafe fn hex_conservative::error::InvalidCharError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::error::InvalidCharError
 pub fn hex_conservative::error::InvalidCharError::from(t: T) -> T
-pub struct hex_conservative::InvalidLengthError
+#[non_exhaustive] pub struct hex_conservative::InvalidLengthError
+pub hex_conservative::InvalidLengthError::expected: usize
+pub hex_conservative::InvalidLengthError::invalid: usize
 impl hex_conservative::error::InvalidLengthError
 pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
 pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize

--- a/api/alloc-only.txt
+++ b/api/alloc-only.txt
@@ -228,6 +228,7 @@ impl<T> core::convert::From<T> for hex_conservative::error::DecodeVariableLength
 pub fn hex_conservative::error::DecodeVariableLengthBytesError::from(t: T) -> T
 pub struct hex_conservative::error::InvalidCharError
 impl hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
 pub fn hex_conservative::error::InvalidCharError::offset(self, by_bytes: usize) -> Self
 pub fn hex_conservative::error::InvalidCharError::pos(&self) -> usize
 impl core::clone::Clone for hex_conservative::error::InvalidCharError
@@ -277,7 +278,9 @@ impl<T> core::clone::CloneToUninit for hex_conservative::error::InvalidCharError
 pub unsafe fn hex_conservative::error::InvalidCharError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::error::InvalidCharError
 pub fn hex_conservative::error::InvalidCharError::from(t: T) -> T
-pub struct hex_conservative::error::InvalidLengthError
+#[non_exhaustive] pub struct hex_conservative::error::InvalidLengthError
+pub hex_conservative::error::InvalidLengthError::expected: usize
+pub hex_conservative::error::InvalidLengthError::invalid: usize
 impl hex_conservative::error::InvalidLengthError
 pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
 pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
@@ -785,6 +788,7 @@ impl<T> core::convert::From<T> for hex_conservative::HexToBytesIter<I>
 pub fn hex_conservative::HexToBytesIter<I>::from(t: T) -> T
 pub struct hex_conservative::InvalidCharError
 impl hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
 pub fn hex_conservative::error::InvalidCharError::offset(self, by_bytes: usize) -> Self
 pub fn hex_conservative::error::InvalidCharError::pos(&self) -> usize
 impl core::clone::Clone for hex_conservative::error::InvalidCharError
@@ -834,7 +838,9 @@ impl<T> core::clone::CloneToUninit for hex_conservative::error::InvalidCharError
 pub unsafe fn hex_conservative::error::InvalidCharError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::error::InvalidCharError
 pub fn hex_conservative::error::InvalidCharError::from(t: T) -> T
-pub struct hex_conservative::InvalidLengthError
+#[non_exhaustive] pub struct hex_conservative::InvalidLengthError
+pub hex_conservative::InvalidLengthError::expected: usize
+pub hex_conservative::InvalidLengthError::invalid: usize
 impl hex_conservative::error::InvalidLengthError
 pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
 pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize

--- a/api/no-features.txt
+++ b/api/no-features.txt
@@ -202,6 +202,7 @@ impl<T> core::convert::From<T> for hex_conservative::error::DecodeVariableLength
 pub fn hex_conservative::error::DecodeVariableLengthBytesError::from(t: T) -> T
 pub struct hex_conservative::error::InvalidCharError
 impl hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
 pub fn hex_conservative::error::InvalidCharError::offset(self, by_bytes: usize) -> Self
 pub fn hex_conservative::error::InvalidCharError::pos(&self) -> usize
 impl core::clone::Clone for hex_conservative::error::InvalidCharError
@@ -245,7 +246,9 @@ impl<T> core::clone::CloneToUninit for hex_conservative::error::InvalidCharError
 pub unsafe fn hex_conservative::error::InvalidCharError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::error::InvalidCharError
 pub fn hex_conservative::error::InvalidCharError::from(t: T) -> T
-pub struct hex_conservative::error::InvalidLengthError
+#[non_exhaustive] pub struct hex_conservative::error::InvalidLengthError
+pub hex_conservative::error::InvalidLengthError::expected: usize
+pub hex_conservative::error::InvalidLengthError::invalid: usize
 impl hex_conservative::error::InvalidLengthError
 pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
 pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize
@@ -703,6 +706,7 @@ impl<T> core::convert::From<T> for hex_conservative::HexToBytesIter<I>
 pub fn hex_conservative::HexToBytesIter<I>::from(t: T) -> T
 pub struct hex_conservative::InvalidCharError
 impl hex_conservative::error::InvalidCharError
+pub fn hex_conservative::error::InvalidCharError::invalid_char(&self) -> u8
 pub fn hex_conservative::error::InvalidCharError::offset(self, by_bytes: usize) -> Self
 pub fn hex_conservative::error::InvalidCharError::pos(&self) -> usize
 impl core::clone::Clone for hex_conservative::error::InvalidCharError
@@ -746,7 +750,9 @@ impl<T> core::clone::CloneToUninit for hex_conservative::error::InvalidCharError
 pub unsafe fn hex_conservative::error::InvalidCharError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for hex_conservative::error::InvalidCharError
 pub fn hex_conservative::error::InvalidCharError::from(t: T) -> T
-pub struct hex_conservative::InvalidLengthError
+#[non_exhaustive] pub struct hex_conservative::InvalidLengthError
+pub hex_conservative::InvalidLengthError::expected: usize
+pub hex_conservative::InvalidLengthError::invalid: usize
 impl hex_conservative::error::InvalidLengthError
 pub fn hex_conservative::error::InvalidLengthError::expected_length(&self) -> usize
 pub fn hex_conservative::error::InvalidLengthError::invalid_length(&self) -> usize

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,7 +160,8 @@ pub struct InvalidCharError {
 impl InvalidCharError {
     /// Returns the invalid character byte.
     #[inline]
-    pub(crate) fn invalid_char(&self) -> u8 { self.invalid }
+    #[deprecated(since = "TBD", note = "not suitable for use with UTF-8 strings")]
+    pub fn invalid_char(&self) -> u8 { self.invalid }
     /// Returns the position of the invalid character byte.
     #[inline]
     pub fn pos(&self) -> usize { self.pos }
@@ -368,11 +369,12 @@ impl From<InvalidLengthError> for DecodeFixedLengthBytesError {
 
 /// Tried to parse fixed-length hash from a string with the wrong length.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct InvalidLengthError {
     /// The expected length.
-    pub(crate) expected: usize,
+    pub expected: usize,
     /// The invalid length.
-    pub(crate) invalid: usize,
+    pub invalid: usize,
 }
 
 impl InvalidLengthError {


### PR DESCRIPTION
We would like to alias the `DecodeFixedLengthBytesError` back into `0.2` and `0.3` as `HexToArrayError` [0].

During the 1.0 dev cycle we made a few minor API breaks. Turns out we were probably overly savage and the benefits of re-instating the previous API outweigh the maintenance risks we were attempting to mitigate.

Put the `InvalidLengthError` and `InvalidCharError` back to how they were when in the `0.3` release.

Done as part of #254

[0] See issue #254 for full context and justification.